### PR TITLE
More router fixes to resolve error in prod

### DIFF
--- a/src/components/exercises/ExerciseCard.vue
+++ b/src/components/exercises/ExerciseCard.vue
@@ -81,7 +81,7 @@
               icon="mdi-file-document-edit"
               class="ma-2"
               variant="outlined"
-              @click='this.$router.push("edit");'/>
+              @click='goToEditor'/>
         </template>
         <span v-html="$t('exercise.edit')"/>
       </v-tooltip>
@@ -247,6 +247,9 @@ function goBack(): void {
   router.back();
 }
 
+function goToEditor(): void {
+  router.push('edit');
+}
 /*
 function reportError(error: string): void {
   console.log(error);

--- a/src/components/exercises/ExerciseEditor.vue
+++ b/src/components/exercises/ExerciseEditor.vue
@@ -241,6 +241,9 @@ import {useRouter, useRoute} from "vue-router";
 import "md-editor-v3/lib/style.css";
 import MarkdownModal from "@/components/helpers/MarkdownModal";
 
+const route = useRoute();
+const router = useRouter();
+
 /*
 function keyDownListener(e) {
   if (e.keyCode === 16) {
@@ -266,9 +269,8 @@ onUnmounted(() => {
 })
 */
 
-const router = useRouter();
-const course = useRoute().params.course;
-const id = useRoute().params.id;
+const course = route.params.course;
+const id = route.params.id;
 const localStoragePath = id === undefined ? course + ".newExercise" : course + ".e." + id;
 
 /*


### PR DESCRIPTION
Seems like using script setup removes the `this.$router...` capabilities, so we need to replace those occurrences with a function call which in turn uses `router...`, which is the result of a single `const router = useRouter()` call.