### PR TITLE
fixed logo not displaying on firefox after switching pages - firefox …

### DIFF
--- a/src/components/navigation/navbar/NavbarBase.vue
+++ b/src/components/navigation/navbar/NavbarBase.vue
@@ -3,9 +3,9 @@
   <v-app-bar id="header" elevation="3" justify="left" height="100px" role="navigation">
     <v-app-bar-title>
       <v-img v-if="theme === 'light'" @click="goToHome()" @keyup.enter.prevent.stop="goToHome"
-             src="@/assets/ATLAS_Logo.svg" max-height="70px"/>
+             src="@/assets/ATLAS_Logo.svg" height="70px"/>
       <v-img v-else @click="goToHome()" @keyup.enter.prevent.stop="goToHome" src="@/assets/ATLAS_Logo_Dark.svg"
-             max-height="70px"/>
+             height="70px"/>
     </v-app-bar-title>
     <CourseButton/>
     <v-spacer/>


### PR DESCRIPTION
Firefox does not support solely using min/max width/height with images in the svg format. It expects one fixed size, otherwise it will be automatically set the attribute to 0, this happened with the logo's height.

See: https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/SVG_Image_Tag