### PR TITLE
fixed logo size on mobile by clamping the width of v-app-bar-title

### DIFF
--- a/src/components/navigation/navbar/NavbarBase.vue
+++ b/src/components/navigation/navbar/NavbarBase.vue
@@ -207,8 +207,4 @@ hr {
   min-width: 100px;
 }
 
-v-app-bar-title {
-  text-overflow: clip;
-}
-
 </style>

--- a/src/components/navigation/navbar/NavbarBase.vue
+++ b/src/components/navigation/navbar/NavbarBase.vue
@@ -1,7 +1,7 @@
 <template>
   <SkipToContent />
-  <v-app-bar id="header" elevation="3" justify="left" height="100px" role="navigation">
-    <v-app-bar-title>
+  <v-app-bar id="header" elevation="3"  height="100px" role="navigation">
+    <v-app-bar-title style="max-width: 200px !important; min-width: 200px !important;">
       <v-img v-if="theme === 'light'" @click="goToHome()" @keyup.enter.prevent.stop="goToHome"
              src="@/assets/ATLAS_Logo.svg" height="70px"/>
       <v-img v-else @click="goToHome()" @keyup.enter.prevent.stop="goToHome" src="@/assets/ATLAS_Logo_Dark.svg"
@@ -11,7 +11,6 @@
     <v-spacer/>
     <v-spacer/>
     <v-spacer/>
-
     <!--nur sichtbar auf Bildschirmen, die groß genug sind, auf mobile findet man das alles im hamburger menu -->
 
     <!-- // disabled until search exists // <v-col>
@@ -208,5 +207,8 @@ hr {
   min-width: 100px;
 }
 
+v-app-bar-title {
+  text-overflow: clip;
+}
 
 </style>


### PR DESCRIPTION
The use of v-spacer elements causes the v-app-bar-title and its child elements to adjust their width automatically, making them smaller.
The use of a fixed width using "width: 200px !important" does not work for some reason, the workaround is using both min- and max-width.

I tried making changes to the navbar component, removing the v-spacer elements, this did not work well either as for some reason elements with the "margin-left: auto" styling did not move to the right side. The "justify-end" class didn't seem to work either.

![Bildschirmfoto vom 2022-05-17 14-18-30](https://user-images.githubusercontent.com/103537276/168809171-d673d19d-1513-45f4-a76e-b24c2b8b4f21.png)
