### PR TITLE
Changed elements and style to match title position to the text below.

### DIFF
--- a/src/components/exercises/ExerciseCard.vue
+++ b/src/components/exercises/ExerciseCard.vue
@@ -99,9 +99,9 @@
       </v-tooltip-->
 
     </v-container>
-
-    <v-card-title class="text-left text-h4"> {{exercise.title}} </v-card-title>
-
+    <v-container>
+    <v-card-title class="text-left text-h4" style="padding-left: 0;"> {{exercise.title}} </v-card-title>
+    </v-container>
     <!--v-container v-if="exercise.images_before && exercise.images_before.length > 0" class="text-left">
       <v-carousel v-model="carousel1" :cycle="false">
         <v-carousel-item v-for="image in exercise.images_before" :key="image.id">


### PR DESCRIPTION
Added a v-container and removed left padding to match the position of the title to the text below on all zoom levels

![grafik](https://user-images.githubusercontent.com/103537276/168861889-746fe0e2-28cc-4897-9d20-ae660c7aa740.png)
![grafik](https://user-images.githubusercontent.com/103537276/168862053-7b0fde5f-f3a0-4940-b3ef-cecccfd04eac.png)

