### PR TITLE
Added titles for currently used views in both languages

### DIFF
--- a/src/components/CourseMainPage.vue
+++ b/src/components/CourseMainPage.vue
@@ -33,12 +33,16 @@
 
 <script setup>
 import MainpageCardModal from "@/components/MainpageCardModal";
-import {defineProps} from "vue";
+import {defineProps, watch} from "vue";
 
 const props = defineProps({
   module: Object,
   exercises: Object,
 });
+
+watch(() => {
+  document.title = props.module.name;
+})
 
 
 </script>

--- a/src/components/exercises/ExerciseCard.vue
+++ b/src/components/exercises/ExerciseCard.vue
@@ -154,9 +154,11 @@ import "md-editor-v3/lib/style.css";
 import MarkdownModal from "@/components/helpers/MarkdownModal.vue";
 import {onBeforeMount, reactive} from "vue";
 import ExerciseService from "@/services/ExerciseService";
+import {useI18n} from "vue-i18n";
 
 const route = useRoute();
 const router = useRouter();
+const i18n = useI18n();
 const id = route.params.id;
 const course = route.params.course;
 let exerciseData: any;
@@ -176,6 +178,8 @@ onBeforeMount(async () => {
   exercise.taskPublic = exerciseData.exercisePublic
 
   await router.replace(`/${course}/e/${id}/${encodeURIComponent(exercise.title)}`)
+
+  document.title = i18n.t('titles.exercise_view') + ' - ' + exercise.title
 })
 
 function goBack() {

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -123,7 +123,8 @@ const translationDe = {
         modulesearch_view: 'Module',
         pagenotfound_view: 'Fehler',
         exercise_view: 'Aufgabe',
-        exerciseeditor_view: 'Bearbeiten'
+        exerciseeditor_view: 'Bearbeiten',
+        module_main_page: 'Modul',
     },
     languages: {
         en: 'Englisch',

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -111,6 +111,20 @@ const translationDe = {
         register: 'Registrieren',
         new: 'Neu',
     },
+    titles: {
+        home_view: 'ATLAS',
+        login_view: 'Login',
+        help_view: 'Hilfe',
+        settings_view: 'Einstellungen',
+        admin_view: 'Admin',
+        exercisemanagement_view: 'Aufgaben',
+        usermanagement_view: 'Benutzer',
+        profile_view: 'Profil',
+        modulesearch_view: 'Module',
+        pagenotfound_view: 'Fehler',
+        exercise_view: 'Aufgabe',
+        exerciseeditor_view: 'Bearbeiten'
+    },
     languages: {
         en: 'Englisch',
         de: 'Deutsch',

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -103,7 +103,8 @@ const translationEn = {
         modulesearch_view: 'Modules',
         pagenotfound_view: 'Error',
         exercise_view: 'Exercise',
-        exerciseeditor_view: 'Edit'
+        exerciseeditor_view: 'Edit',
+        module_main_page: 'Module',
     },
     buttons: {
         save: 'Save',

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -91,6 +91,20 @@ const translationEn = {
                 'When using your LDAP account to sign into ATLAS, a new account will be created.',
         },
     },
+    titles: {
+        home_view: 'ATLAS',
+        login_view: 'Login',
+        help_view: 'Help',
+        settings_view: 'Settings',
+        admin_view: 'Admin',
+        exercisemanagement_view: 'Exercises',
+        usermanagement_view: 'Users',
+        profile_view: 'Profile',
+        modulesearch_view: 'Modules',
+        pagenotfound_view: 'Error',
+        exercise_view: 'Exercise',
+        exerciseeditor_view: 'Edit'
+    },
     buttons: {
         save: 'Save',
         cancel: 'Cancel',

--- a/src/views/CourseSearchView.vue
+++ b/src/views/CourseSearchView.vue
@@ -14,6 +14,8 @@
 import Navbar from '@/components/navigation/navbar/NavbarBase.vue'
 import CourseSearch from "@/components/CourseSearch.vue";
 import Footer from "@/components/navigation/FooterCard.vue";
+import {useI18n} from "vue-i18n";
+document.title = useI18n().t('titles.modulesearch_view');
 </script>
 
 <style scoped>

--- a/src/views/HelpView.vue
+++ b/src/views/HelpView.vue
@@ -20,4 +20,6 @@
 import Navbar from "@/components/navigation/navbar/NavbarBase.vue";
 import Help from "@/components/HelpCard.vue";
 import Footer from "@/components/navigation/FooterCard.vue";
+import {useI18n} from "vue-i18n";
+document.title = useI18n().t('titles.help_view');
 </script>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -15,7 +15,9 @@
 import HomeContent from "@/components/HomeContent.vue";
 import Footer from "@/components/navigation/FooterCard.vue";
 import NavbarBase from "@/components/navigation/navbar/NavbarBase.vue";
+import {useI18n} from "vue-i18n";
 
+document.title = useI18n().t('titles.home_view');
 </script>
 
 <style scoped>

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -12,4 +12,6 @@
 <script lang='ts' setup>
 import LoginModal from "@/components/LoginModal.vue";
 import Footer from "@/components/navigation/FooterCard.vue";
+import {useI18n} from "vue-i18n";
+document.title = useI18n().t('titles.login_view');
 </script>

--- a/src/views/PageNotFoundView.vue
+++ b/src/views/PageNotFoundView.vue
@@ -25,4 +25,7 @@
 import Navbar from "@/components/navigation/navbar/NavbarBase.vue";
 import PageNotFound from "@/components/navigation/PageNotFound.vue";
 import Footer from "@/components/navigation/FooterCard.vue";
+import {useI18n} from "vue-i18n";
+
+useI18n().t('titles.pagenotfound_view')
 </script>

--- a/src/views/ProfileView.vue
+++ b/src/views/ProfileView.vue
@@ -14,6 +14,8 @@
 import Profile from "@/components/ProfileCard"
 import Navbar from "@/components/navigation/navbar/NavbarBase.vue";
 import Footer from "@/components/navigation/FooterCard.vue"
+import {useI18n} from "vue-i18n";
+document.title = useI18n().t('titles.profile_view');
 </script>
 
 <style scoped>

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -25,4 +25,7 @@
 import Navbar from "@/components/navigation/navbar/NavbarBase.vue";
 import Settings from "@/components/SettingsCard.vue";
 import Footer from "@/components/navigation/FooterCard.vue";
+import {useI18n} from "vue-i18n";
+
+document.title = useI18n().t('titles.settings_view');
 </script>

--- a/src/views/admin/AdminView.vue
+++ b/src/views/admin/AdminView.vue
@@ -21,4 +21,6 @@
 
 <script setup lang='ts'>
 import NavbarAdmin from "@/components/admin/NavbarAdmin.vue";
+import {useI18n} from "vue-i18n";
+document.title = useI18n().t('titles.admin_view');
 </script>

--- a/src/views/admin/TaskManagementView.vue
+++ b/src/views/admin/TaskManagementView.vue
@@ -18,4 +18,6 @@
 <script setup lang='ts'>
 import TaskManagement from "@/components/admin/TaskManagement.vue";
 import NavbarAdmin from "@/components/admin/NavbarAdmin.vue";
+import {useI18n} from "vue-i18n";
+document.title = useI18n().t('titles.exercisemanagement_view');
 </script>

--- a/src/views/admin/UserManagementView.vue
+++ b/src/views/admin/UserManagementView.vue
@@ -18,4 +18,6 @@
 <script setup lang='ts'>
 import UserManagement from "@/components/admin/UserManagement.vue";
 import NavbarAdmin from "@/components/admin/NavbarAdmin.vue";
+import {useI18n} from "vue-i18n";
+document.title = useI18n().t('titles.usermanagement_view');
 </script>

--- a/src/views/exercises/ExerciseEditorView.vue
+++ b/src/views/exercises/ExerciseEditorView.vue
@@ -25,4 +25,7 @@
 import Navbar from "@/components/navigation/navbar/NavbarBase.vue";
 import ExerciseEditor from "@/components/exercises/ExerciseEditor.vue";
 import Footer from "@/components/navigation/FooterCard.vue";
+import {useI18n} from "vue-i18n";
+
+useI18n().t('titles.exerciseeditor_view')
 </script>

--- a/src/views/exercises/ExerciseView.vue
+++ b/src/views/exercises/ExerciseView.vue
@@ -25,7 +25,4 @@
 import Navbar from "@/components/navigation/navbar/NavbarBase.vue";
 import Exercise from "@/components/exercises/ExerciseCard.vue";
 import Footer from "@/components/navigation/FooterCard.vue";
-import {useI18n} from "vue-i18n";
-
-useI18n().t('titles.exercise_view')
 </script>

--- a/src/views/exercises/ExerciseView.vue
+++ b/src/views/exercises/ExerciseView.vue
@@ -25,4 +25,7 @@
 import Navbar from "@/components/navigation/navbar/NavbarBase.vue";
 import Exercise from "@/components/exercises/ExerciseCard.vue";
 import Footer from "@/components/navigation/FooterCard.vue";
+import {useI18n} from "vue-i18n";
+
+useI18n().t('titles.exercise_view')
 </script>


### PR DESCRIPTION
Sadly, switching the language in the settings page does not manipulate the title. For the change to apply, the page needs to be revisited. (refreshing does not work because the language is currently not saved in the browsers localstorage)