### PR TITLE
Descriptions now don't have a scrollbar when the exercise has one

### DIFF
--- a/src/components/admin/TaskManagement.vue
+++ b/src/components/admin/TaskManagement.vue
@@ -78,12 +78,12 @@
         </v-card-title>
         <v-card-text>
           <span v-if="viewExerciseDialog.target.description" v-html="viewExerciseDialog.target.description"/>
-        </v-card-text>
         <v-container class="my">
           <MarkdownModal
               :model-value="viewExerciseDialog.target.content"
           />
         </v-container>
+        </v-card-text>
       </v-card>
     </v-dialog>
 


### PR DESCRIPTION
Moving MarkdownModal into the v-card-text element fixed it.