### PR TITLE
Added resolutions block in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,9 @@
     "vue-cli-plugin-vuetify": "~2.4.8",
     "vuetify-loader": "^2.0.0-alpha.0"
   },
+  "resolutions": {
+    "error-stack-parser": "2.0.6"
+  },
   "eslintConfig": {
     "root": true,
     "env": {


### PR DESCRIPTION
Forces `error-stack-parser` version to `2.0.6` to avoid conflict with vue-cli dependency
Should close #206 