### PR TITLE
Changed color of hyperlinks

### DIFF
--- a/src/helpers/theme.ts
+++ b/src/helpers/theme.ts
@@ -37,6 +37,7 @@ export const lightTheme: ThemeDefinition = {
         text: '#394a59',
         link: '#9c132e',
         skipLink: '#4a5c66',
+        hyperlink: '#272ef5',
     }
 };
 
@@ -55,5 +56,6 @@ export const darkTheme: ThemeDefinition = {
         warning: '#FB8C00',
         highlight: '#3d3d3d',
         skipLink: '#FFFFFF',
+        hyperlink: '#34ebe5',
     }
 };

--- a/src/main.scss
+++ b/src/main.scss
@@ -21,3 +21,7 @@
 .v-text-field {
   font-family: 'Courier New', serif; // set font: Courier New for input fields
 }
+
+a {
+  color: rgb(var(--v-theme-hyperlink));
+}


### PR DESCRIPTION
Added a color for hyperlinks in theme.ts, "a" tags now use this color (using main.scss)

Link in light theme:
![grafik](https://user-images.githubusercontent.com/103537276/173194286-d0be0a2f-4934-4caf-b7aa-c39c8d305377.png)

Link in dark theme:
![grafik](https://user-images.githubusercontent.com/103537276/173194338-b1069953-8a06-4482-8109-d08892224ee5.png)
