### PR TITLE
added css class for hyperlinks in FooterCard.vue

### DIFF
--- a/src/components/navigation/FooterCard.vue
+++ b/src/components/navigation/FooterCard.vue
@@ -13,7 +13,7 @@
           <v-card-text>
             <v-btn class="mx-4" elevation="0" color="secondary" v-for="link in links" :key="link[0]"
                    @click.prevent.stop="link[1]">
-              <a>{{ $t(`footer.${link[0]}`) }}</a>
+              <a class="footerHyperlink">{{ $t(`footer.${link[0]}`) }}</a>
             </v-btn>
           </v-card-text>
         </v-row>
@@ -76,5 +76,9 @@ let links = [
 
 #h-line {
   border-top: 1px solid #b7b7b7;
+}
+
+.footerHyperlink{
+  color: white;
 }
 </style>


### PR DESCRIPTION
Added a css class to FooterCard.vue to set the color of hyperlinks to white.

![grafik](https://user-images.githubusercontent.com/103537276/173253258-45c0bd28-532b-453d-89ef-430febc3349f.png)

![grafik](https://user-images.githubusercontent.com/103537276/173253270-b3a0f92e-1326-4a73-a5d5-db2fb894695a.png)
