### PR TITLE
added z-index to v-expansion-panels

### DIFF
--- a/src/components/HelpCard.vue
+++ b/src/components/HelpCard.vue
@@ -24,7 +24,7 @@
         </div>
         <br/>
         <div class="accordion-panel">
-          <v-expansion-panels>
+          <v-expansion-panels style="z-index: 0">
             <v-expansion-panel rounded="0" elevation="0">
               <v-expansion-panel-title
                   expand-icon="mdi-plus"


### PR DESCRIPTION
![grafik](https://user-images.githubusercontent.com/103537276/173632626-40637bc9-e12c-414f-b3aa-67bf5277197f.png)

Expansion panels don't overlap with the navbar now.