### PR TITLE
Change lazy-src to src so image gets displayed properly on first load

### DIFF
--- a/src/components/ModuleMainPage.vue
+++ b/src/components/ModuleMainPage.vue
@@ -5,10 +5,9 @@
       <!-- todo: Image loaded from backend -->
       <div>
         <v-img
-            lazy-src="@/assets/ModuleMainPage/pexels-hitarth-jadhav.jpg"
+            src="@/assets/ModuleMainPage/pexels-hitarth-jadhav.jpg"
             max-height="240px"
             width="100%"
-            src=""
             cover
         >
           <div class="moduleNameContainer">


### PR DESCRIPTION
This bug seems to appear when loading the image from a `lazy-src`. 

When loading from just a `src` the image will be displayed properly (atleast in my browser...). For now we could change the `v-img` to load from a `src` instead of the `lazy-src`.