### PR TITLE
344 major filter exercises of a module by tag

### DIFF
--- a/src/components/ModuleMainPage.vue
+++ b/src/components/ModuleMainPage.vue
@@ -11,7 +11,10 @@
             cover
         >
           <div class="moduleNameContainer">
-            <h1>{{ module.name }}</h1>
+            <v-row align="center">
+              <v-icon size="large" icon="mdi-animation" style="margin-right: 0.3em;"></v-icon>
+              <h1>{{ module.name }}</h1>
+            </v-row>
           </div>
         </v-img>
       </div>
@@ -318,6 +321,7 @@ import {Exercise, Module, User, ModuleUser, Tag} from "@/helpers/types";
 import { useI18n } from "vue-i18n";
 import ModuleManager from "@/components/ModuleManager.vue";
 import TagService from "@/services/TagService";
+import IconService from "@/services/IconService";
 
 const route = useRoute();
 const i18n = useI18n();
@@ -340,11 +344,15 @@ const label = ref({
 const selectedTag = ref({
   value: ''
 })
+const icon = ref({
+  value: 'mdi-cog'
+})
 
 async function loadModule(): Promise<void> {
   ModuleService.getModule(route.params.module instanceof Array ? route.params.module[0] : route.params.module)
       .then((res) => {
         module.value = res.data;
+        //icon.value.value = module.value.icon.reference;
         loadUsers();
         document.title = module.value.name;
         ExerciseService.getExercisesForModule(module.value.module_id).then(
@@ -442,8 +450,6 @@ function getUserTemplate(): ModuleUser {
 }
 
 function filter(tag: Tag): void {
-  console.log(tag);
-  console.log(TagService.getAllTags());
   selectedTag.value.value == tag.name ? selectedTag.value.value = '' : selectedTag.value.value = tag.name;
 }
 
@@ -464,8 +470,9 @@ function setExercise(exercise: Exercise): boolean {
 
 function getAllModuleTags(): void {
   TagService.getModuleTags(module.value).then(res => {
-    moduleTags.value = res.data;
-    console.log(moduleTags.value);
+    const filteredTags: Ref<Tag[]> = ref([]);
+    res.data.forEach((tag: Tag) => filteredTags.value.map(t => t.tag_id).includes(tag.tag_id) ? 'nothing' : filteredTags.value.push(tag));
+    moduleTags.value = filteredTags.value;
   })
 }
 </script>

--- a/src/components/ModuleMainPage.vue
+++ b/src/components/ModuleMainPage.vue
@@ -56,6 +56,10 @@
     @click="delModuleTags()">
       Remove Tags
     </v-btn>
+    <v-btn
+    @click="delOne()">
+      DEL ONE
+    </v-btn>
       </div>
       <v-card
           class="moduleInfoBox rounded-0"
@@ -481,6 +485,18 @@ function delModuleTags(): void {
   TagService.delTagFromModule(module.value, t).then((res) => {
     console.log(res.data);
   })
+}
+
+function delOne(): void {
+  const t = {
+    tag_id: 71,
+    name: "Autom",
+    icon: {
+      icon_id: 1,
+      reference: "mdi-laptop"
+    }
+  }
+  TagService.delTag(t);
 }
 </script>
 

--- a/src/components/ModuleMainPage.vue
+++ b/src/components/ModuleMainPage.vue
@@ -41,6 +41,10 @@
           <span v-html="$t('buttons.edit')"/>
         </v-tooltip>
     <v-btn
+    @click="consoleAllTags()">
+      All Tags
+    </v-btn>
+    <v-btn
     @click="getModuleTags()">
       Get Tags
     </v-btn>
@@ -445,19 +449,28 @@ function getUserTemplate(): ModuleUser {
  * New
  */
 
+function consoleAllTags(): void {
+  TagService.getAllTags().then(res => {
+    console.log(res.data);
+  })
+}
+
 function getModuleTags(): void {
   //console.log(TagService.getAllTags());
   //console.log(module.value);
-  const t = TagService.getModuleTags(module.value);
-  console.log(t);
+  TagService.getModuleTags(module.value).then(res => {
+    console.log(res.data);
+  })
 }
 
 function setModuleTags(): void {
   const t = {
-    tag_id: 25,
-    name: "Unix"
+    tag_id: 3,
+    name: "Laufzeit"
   }
-  console.log(TagService.addTagToModule(module.value, t));
+  TagService.addTagToModule(module.value, t).then((res) => {
+    console.log(res.data);
+  })
 }
 
 function delModuleTags(): void {
@@ -465,8 +478,9 @@ function delModuleTags(): void {
     tag_id: 25,
     name: "Unix"
   }
-  console.log(TagService.delTagFromModule(module.value, t));
-  console.log(TagService.delTagFromModule(module.value, {tag_id: 25, name: "Unix"}));
+  TagService.delTagFromModule(module.value, t).then((res) => {
+    console.log(res.data);
+  })
 }
 </script>
 

--- a/src/components/ModuleMainPage.vue
+++ b/src/components/ModuleMainPage.vue
@@ -65,15 +65,12 @@
           </v-row>
         </v-card-text>
       </v-card>
-      <v-template
-      v-for="exercise in exercises"
-      v-bind:key="exercise.exercise_id">
         <v-chip
-        v-for="tag in exercise.tags" :key="tag.tag_id"
+        v-for="tag in moduleTags" :key="tag.tag_id"
         @click="filter(tag)">
+        <v-icon class="tag-icon" size="small" :icon="tag.icon.reference"></v-icon>
         {{ tag.name }}
         </v-chip>
-      </v-template>
       <v-container fluid>
         <v-row>
           <v-col cols="9">
@@ -328,6 +325,7 @@ const i18n = useI18n();
 const module: Ref<Module> = ref({}) as Ref<Module>;
 const moduleUsers: Ref<ModuleUser[]> = ref([]);
 const exercises: Ref<Array<Exercise>> = ref([]);
+const moduleTags: Ref<Tag[]> = ref([]);
 const tab = ref(0);
 const teachers: Ref<Array<User>> = ref([]);
 const tutors: Ref<Array<User>> = ref([]);
@@ -353,6 +351,7 @@ async function loadModule(): Promise<void> {
             (e) => {
               exercises.value = e.data;
               getAssignStatus();
+              getAllModuleTags();
             }
         );
       })
@@ -443,7 +442,9 @@ function getUserTemplate(): ModuleUser {
 }
 
 function filter(tag: Tag): void {
-  selectedTag.value.value == '' ? selectedTag.value.value = tag.name : selectedTag.value.value = '';
+  console.log(tag);
+  console.log(TagService.getAllTags());
+  selectedTag.value.value == tag.name ? selectedTag.value.value = '' : selectedTag.value.value = tag.name;
 }
 
 function setExercise(exercise: Exercise): boolean {
@@ -453,14 +454,19 @@ function setExercise(exercise: Exercise): boolean {
   else {
     exercise.tags.forEach((tag: Tag) => {
       if(tag.name.toLowerCase() == selectedTag.value.value.toLowerCase()) {
-        console.log("true")
         console.log(exercise);
         return true;
       }
     })
-    console.log("false")
     return false;
   }
+}
+
+function getAllModuleTags(): void {
+  TagService.getModuleTags(module.value).then(res => {
+    moduleTags.value = res.data;
+    console.log(moduleTags.value);
+  })
 }
 </script>
 
@@ -600,5 +606,9 @@ function setExercise(exercise: Exercise): boolean {
 
 .tag-container {
   margin-left: 2em;
+}
+
+.tag-icon {
+  margin-right: 0.2em;
 }
 </style>

--- a/src/components/ModuleMainPage.vue
+++ b/src/components/ModuleMainPage.vue
@@ -40,26 +40,6 @@
           </template>
           <span v-html="$t('buttons.edit')"/>
         </v-tooltip>
-    <v-btn
-    @click="consoleAllTags()">
-      All Tags
-    </v-btn>
-    <v-btn
-    @click="getModuleTags()">
-      Get Tags
-    </v-btn>
-    <v-btn
-    @click="setModuleTags()">
-      Set Tags
-    </v-btn>
-    <v-btn
-    @click="delModuleTags()">
-      Remove Tags
-    </v-btn>
-    <v-btn
-    @click="delOne()">
-      DEL ONE
-    </v-btn>
       </div>
       <v-card
           class="moduleInfoBox rounded-0"
@@ -447,56 +427,6 @@ function getUserTemplate(): ModuleUser {
     username: "",
     email: "",
   };
-}
-
-/**
- * New
- */
-
-function consoleAllTags(): void {
-  TagService.getAllTags().then(res => {
-    console.log(res.data);
-  })
-}
-
-function getModuleTags(): void {
-  //console.log(TagService.getAllTags());
-  //console.log(module.value);
-  TagService.getModuleTags(module.value).then(res => {
-    console.log(res.data);
-  })
-}
-
-function setModuleTags(): void {
-  const t = {
-    tag_id: 3,
-    name: "Laufzeit"
-  }
-  TagService.addTagToModule(module.value, t).then((res) => {
-    console.log(res.data);
-  })
-}
-
-function delModuleTags(): void {
-  const t = {
-    tag_id: 25,
-    name: "Unix"
-  }
-  TagService.delTagFromModule(module.value, t).then((res) => {
-    console.log(res.data);
-  })
-}
-
-function delOne(): void {
-  const t = {
-    tag_id: 71,
-    name: "Autom",
-    icon: {
-      icon_id: 1,
-      reference: "mdi-laptop"
-    }
-  }
-  TagService.delTag(t);
 }
 </script>
 

--- a/src/components/ModuleMainPage.vue
+++ b/src/components/ModuleMainPage.vue
@@ -65,6 +65,15 @@
           </v-row>
         </v-card-text>
       </v-card>
+      <v-template
+      v-for="exercise in exercises"
+      v-bind:key="exercise.exercise_id">
+        <v-chip
+        v-for="tag in exercise.tags" :key="tag.tag_id"
+        @click="filter(tag)">
+        {{ tag.name }}
+        </v-chip>
+      </v-template>
       <v-container fluid>
         <v-row>
           <v-col cols="9">
@@ -83,6 +92,7 @@
                       style="display: inline-flex; text-align: center"
                   >
                     <v-card
+                        v-if="setExercise(exercise)"
                         class="exerciseCard"
                         tabindex="0"
                         @keyup.enter.prevent.stop="goToExercise(exercise)"
@@ -329,6 +339,9 @@ const label = ref({
   user: user.value,
   assigned: false,
 });
+const selectedTag = ref({
+  value: ''
+})
 
 async function loadModule(): Promise<void> {
   ModuleService.getModule(route.params.module instanceof Array ? route.params.module[0] : route.params.module)
@@ -427,6 +440,27 @@ function getUserTemplate(): ModuleUser {
     username: "",
     email: "",
   };
+}
+
+function filter(tag: Tag): void {
+  selectedTag.value.value == '' ? selectedTag.value.value = tag.name : selectedTag.value.value = '';
+}
+
+function setExercise(exercise: Exercise): boolean {
+  if(selectedTag.value.value == '') {
+    return true;
+  }
+  else {
+    exercise.tags.forEach((tag: Tag) => {
+      if(tag.name.toLowerCase() == selectedTag.value.value.toLowerCase()) {
+        console.log("true")
+        console.log(exercise);
+        return true;
+      }
+    })
+    console.log("false")
+    return false;
+  }
 }
 </script>
 
@@ -562,5 +596,9 @@ function getUserTemplate(): ModuleUser {
   margin-left: auto;
   margin-right: 8px;
   display: block;
+}
+
+.tag-container {
+  margin-left: 2em;
 }
 </style>

--- a/src/components/ModuleMainPage.vue
+++ b/src/components/ModuleMainPage.vue
@@ -40,6 +40,18 @@
           </template>
           <span v-html="$t('buttons.edit')"/>
         </v-tooltip>
+    <v-btn
+    @click="getModuleTags()">
+      Get Tags
+    </v-btn>
+    <v-btn
+    @click="setModuleTags()">
+      Set Tags
+    </v-btn>
+    <v-btn
+    @click="delModuleTags()">
+      Remove Tags
+    </v-btn>
       </div>
       <v-card
           class="moduleInfoBox rounded-0"
@@ -310,6 +322,7 @@ import UserService from "@/services/UserService";
 import {Exercise, Module, User, ModuleUser} from "@/helpers/types";
 import { useI18n } from "vue-i18n";
 import ModuleManager from "@/components/ModuleManager.vue";
+import TagService from "@/services/TagService";
 
 const route = useRoute();
 const i18n = useI18n();
@@ -426,6 +439,32 @@ function getUserTemplate(): ModuleUser {
     username: "",
     email: "",
   };
+}
+
+/**
+ * New
+ */
+
+function getModuleTags(): void {
+  //console.log(TagService.getAllTags());
+  //console.log(module.value);
+  console.log(TagService.getModuleTags(module.value));
+}
+
+function setModuleTags(): void {
+  const t = {
+    tag_id: 25,
+    name: "Unix"
+  }
+  TagService.addTagToModule(module.value, t);
+}
+
+function delModuleTags(): void {
+  const t = {
+    tag_id: 25,
+    name: "Unix"
+  }
+  TagService.delTagFromModule(module.value, t);
 }
 </script>
 

--- a/src/components/ModuleMainPage.vue
+++ b/src/components/ModuleMainPage.vue
@@ -319,7 +319,7 @@ import {useRoute, useRouter} from "vue-router";
 import ModuleService from "@/services/ModuleService";
 import ExerciseService from "@/services/ExerciseService";
 import UserService from "@/services/UserService";
-import {Exercise, Module, User, ModuleUser} from "@/helpers/types";
+import {Exercise, Module, User, ModuleUser, Tag} from "@/helpers/types";
 import { useI18n } from "vue-i18n";
 import ModuleManager from "@/components/ModuleManager.vue";
 import TagService from "@/services/TagService";
@@ -448,7 +448,8 @@ function getUserTemplate(): ModuleUser {
 function getModuleTags(): void {
   //console.log(TagService.getAllTags());
   //console.log(module.value);
-  console.log(TagService.getModuleTags(module.value));
+  const t = TagService.getModuleTags(module.value);
+  console.log(t);
 }
 
 function setModuleTags(): void {
@@ -456,7 +457,7 @@ function setModuleTags(): void {
     tag_id: 25,
     name: "Unix"
   }
-  TagService.addTagToModule(module.value, t);
+  console.log(TagService.addTagToModule(module.value, t));
 }
 
 function delModuleTags(): void {
@@ -464,7 +465,8 @@ function delModuleTags(): void {
     tag_id: 25,
     name: "Unix"
   }
-  TagService.delTagFromModule(module.value, t);
+  console.log(TagService.delTagFromModule(module.value, t));
+  console.log(TagService.delTagFromModule(module.value, {tag_id: 25, name: "Unix"}));
 }
 </script>
 

--- a/src/components/ModuleMainPage.vue
+++ b/src/components/ModuleMainPage.vue
@@ -8,7 +8,7 @@
             src="@/assets/ModuleMainPage/pexels-hitarth-jadhav.jpg"
             max-height="240px"
             width="100%"
-            cover
+            :cover="true"
         >
           <div class="moduleNameContainer">
             <v-row align="center">
@@ -54,7 +54,7 @@
             <v-col cols="10">
               {{ module.description }}
             </v-col>
-            <v-col align="right" cols="2">
+            <v-col cols="2">
               <v-tooltip top>
                 <template v-slot:activator="{ props }">
                     <v-btn @click="reassign" color="secondary" v-bind="props">
@@ -68,15 +68,17 @@
           </v-row>
         </v-card-text>
       </v-card>
-        <v-chip
-        v-for="tag in moduleTags" :key="tag.tag_id"
-        @click="filter(tag)">
-        <v-icon class="tag-icon" size="small" :icon="tag.icon.reference"></v-icon>
-        {{ tag.name }}
-        </v-chip>
       <v-container fluid>
         <v-row>
           <v-col cols="9">
+            <v-chip
+                class="ma-1 mb-3"
+                v-for="tag in moduleTags" :key="tag.tag_id"
+                @click="filter(tag)"
+                :color="selectedTag.value === tag.name ? 'info' : ''">
+              <v-icon class="tag-icon" size="small" :icon="tag.icon.reference" />
+              {{ tag.name }}
+            </v-chip>
             <v-expansion-panels style="z-index: 0" v-model="panel">
               <v-expansion-panel rounded="0" key="0">
                 <v-expansion-panel-title
@@ -198,7 +200,7 @@
               src="@/assets/ModuleMainPage/pexels-hitarth-jadhav.jpg"
               max-height="70px"
               width="100%"
-              cover
+              :cover="true"
           />
           <v-card color="highlight" rounded="0" class="pb-0">
             <h1 class="mobileModuleTitle">
@@ -321,7 +323,6 @@ import {Exercise, Module, User, ModuleUser, Tag} from "@/helpers/types";
 import { useI18n } from "vue-i18n";
 import ModuleManager from "@/components/ModuleManager.vue";
 import TagService from "@/services/TagService";
-import IconService from "@/services/IconService";
 
 const route = useRoute();
 const i18n = useI18n();
@@ -336,6 +337,7 @@ const tutors: Ref<Array<User>> = ref([]);
 const assignedStatus = ref();
 const user: Ref<User> = ref({}) as Ref<User>;
 const panel: Ref<Array<Number>> = ref([0]); // 0 = panel shown, 1 = panel hidden
+
 const label = ref({
   value: "",
   user: user.value,
@@ -343,9 +345,6 @@ const label = ref({
 });
 const selectedTag = ref({
   value: ''
-})
-const icon = ref({
-  value: 'mdi-cog'
 })
 
 async function loadModule(): Promise<void> {
@@ -458,12 +457,11 @@ function setExercise(exercise: Exercise): boolean {
     return true;
   }
   else {
-    exercise.tags.forEach((tag: Tag) => {
-      if(tag.name.toLowerCase() == selectedTag.value.value.toLowerCase()) {
-        console.log(exercise);
+    for (let tag of exercise.tags) {
+      if (tag.name.toLowerCase() == selectedTag.value.value.toLowerCase()) {
         return true;
       }
-    })
+    }
     return false;
   }
 }

--- a/src/components/ModuleManager.vue
+++ b/src/components/ModuleManager.vue
@@ -153,64 +153,6 @@
       </v-card>
     </v-dialog>
       <!-- [Desktop] -->
-      <!-- [Mobile] -->
-    <v-dialog
-        class="d-md-none"
-        v-model="manageTagsDialog.show"
-        :retain-focus="false"
-        transition="slide-y-transition"
-    >
-      <v-card top="20%" width="80vw">
-        <v-card-title> {{ $t("module_manager.edit_tag") }}</v-card-title>
-        <v-card-text>
-          <v-table fixed-header height="400px">
-            <thead>
-            <tr>
-              <th class="hide-btn-behind-header">{{ $t("module_manager.tag") }}</th>
-              <th class="hide-btn-behind-header"></th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr v-for="tag in tagsCurrent" v-bind:key="tag.tag_id">
-              <td>
-                <v-container class="test-class">
-                  <v-text-field
-                      vertical-align="middle"
-                      class="centered-input extend"
-                      v-model="tag.name"
-                  />
-                </v-container>
-              </td>
-              <td class="text-right">
-                <v-btn
-                    class="manage-button"
-                    @click="editTag(tag)"
-                    color="primary"
-                >
-                  <v-icon icon="mdi-content-save"></v-icon>
-                </v-btn>
-                <v-btn
-                    class="manage-button"
-                    @click="removeTag(tag)"
-                    color="error"
-                >
-                  <v-icon icon="mdi-delete"></v-icon>
-                </v-btn>
-              </td>
-            </tr>
-            </tbody>
-          </v-table>
-        </v-card-text>
-        <v-card-actions>
-          <v-btn
-              @click="manageTagsDialog.show = false"
-              color="error"
-              v-html="$t('buttons.close')"
-          />
-        </v-card-actions>
-      </v-card>
-    </v-dialog>
-      <!-- [Mobile] -->
     <!-- Edit tags dialog end -->
 
     <!-- Edit users dialog start -->
@@ -264,56 +206,6 @@
       </v-card>
     </v-dialog>
       <!-- [Desktop] -->
-      <!-- [Mobile] -->
-    <v-dialog
-        class="d-md-none"
-        v-model="editPrivilegeDialog.show"
-        :retain-focus="false"
-        transition="slide-y-transition"
-    >
-      <v-card top="15%" width="80vw">
-        <v-card-title> {{ $t("module_manager.edit_privilege") }}</v-card-title>
-        <v-card-text>
-          <v-radio-group v-model="editPrivilegeDialog.userRole">
-            <v-radio
-                :label="$t('module_manager.student')"
-                :key="1"
-                value="student"
-            />
-            <v-radio
-                :label="$t('module_manager.tutor')"
-                value="tutor"
-                :key="2"
-            />
-            <v-radio
-                :label="$t('module_manager.teacher')"
-                value="teacher"
-                :key="3"
-            />
-          </v-radio-group>
-        </v-card-text>
-        <v-card-actions>
-          <v-btn
-              @click="
-              editPrivilegeDialog.show = false;
-              editPrivilegeDialog.userRole = null;
-              editPrivilegeDialog.user = null;
-            "
-              color="error"
-              v-html="$t('buttons.close')"
-          />
-          <v-btn
-              @click="
-              editPrivilegeDialog.show = false;
-              setUserRole(editPrivilegeDialog.user, editPrivilegeDialog.userRole);
-            "
-              color="primary"
-              v-html="$t('buttons.save')"
-          />
-        </v-card-actions>
-      </v-card>
-    </v-dialog>
-      <!-- [Mobile] -->
     <!-- Edit users dialog end -->
 
     <!-- Edit users dialog start -->
@@ -354,43 +246,6 @@
       </v-card>
     </v-dialog>
       <!-- [Desktop] -->
-      <!-- [Mobile] -->
-    <v-dialog
-        class="d-md-none"
-        v-model="manageUsersDialog.show"
-        :retain-focus="false"
-        transition="slide-y-transition"
-    >
-      <v-card top="20%" width="80vw">
-        <v-card-title> {{ $t("module_manager.add_user") }}</v-card-title>
-        <v-table fixed-header height="400px">
-          <thead>
-          <tr>
-            <th>{{ $t("module_manager.name") }}</th>
-            <th class="hide-btn-behind-header"></th>
-          </tr>
-          </thead>
-          <tbody>
-          <tr v-for="user in filteredUsers" v-bind:key="user.user_id">
-            <td>{{ user.name }}</td>
-            <td class="text-right">
-              <v-btn @click="addModuleUser(user.user_id)" color="primary">
-                <v-icon icon="mdi-account-plus"></v-icon>
-              </v-btn>
-            </td>
-          </tr>
-          </tbody>
-        </v-table>
-        <v-card-actions>
-          <v-btn
-              @click="manageUsersDialog.show = false"
-              color="error"
-              v-html="$t('buttons.close')"
-          />
-        </v-card-actions>
-      </v-card>
-    </v-dialog>
-      <!-- [Mobile] -->
     <!-- Edit users dialog end -->
   </v-container>
 </template>
@@ -512,25 +367,83 @@ const editPrivilegeDialog = ref({
 }>;
 
 function getCurrentTags(): void {
-  ExerciseService.getExercisesForModule(module.value.module_id).then((res) => {
-    exercises.value = [];
-    tagsCurrent.value = [];
-    exercises.value = res.data;
-    exercises.value.forEach((ex) => {
-      ex.tags.forEach((t) => tagsCurrent.value.push(t));
-    });
-  });
+  TagService.getModuleTags(module.value).then(res => {
+    tagsCurrent.value = res.data;
+    //console.log(tagsCurrent.value);
+  })
 }
 
-function editTag(tag: Tag): void {
-  TagService.editTag(tag);
+function editTag(toBeEditedTag: Tag): void {
+  TagService.getAllTags().then(res => {
+    let tagFound = false;
+    res.data.forEach((foundTag: Tag) => {
+      //If find tag already exists with the new name
+      if(foundTag.name.toLowerCase() == toBeEditedTag.name.toLowerCase()) {
+        ExerciseService.getExercisesForModule(module.value.module_id).then(res => {
+          res.data.forEach((exercise: Exercise) => {
+            exercise.tags.forEach((exerciseTag: Tag) => {
+              if(exerciseTag.tag_id == toBeEditedTag.tag_id) {
+                TagService.addTagToExercise(foundTag, exercise);
+                TagService.delTagFromExercise(exerciseTag, exercise);
+                TagService.delTagFromModule(module.value, toBeEditedTag);
+                console.log(TagService.addTagToModule(module.value, foundTag));
+              }
+            })
+          })
+        })
+      }
+    })
+    //There is no other tag with the same name
+    if(!tagFound) {
+      const newTag = {
+        tag_id: 0,
+        name: toBeEditedTag.name,
+      };
+      //Add tag globally
+      TagService.addTag(newTag).then(() => {
+        //Get the newly added tag
+        const newlyAddedTag: Ref<Tag> = ref({}) as Ref<Tag>
+        TagService.getAllTags().then(res => {
+          res.data.forEach((allTag: Tag) => {
+            if(allTag.name.toLowerCase() == newTag.name.toLowerCase()) newlyAddedTag.value = allTag
+          })
+        })
+        //Get all exercises
+        ExerciseService.getExercisesForModule(module.value.module_id).then(res => {
+          //For each exercise ...
+          res.data.forEach((exercise: Exercise) => {
+            //... there are tags of whitch ...
+            exercise.tags.forEach((exerciseTag: Tag) => {
+              //... a tag is found that has to be replaced because it still is the toBeEditedTag
+              if(exerciseTag.tag_id == toBeEditedTag.tag_id) {
+                TagService.addTagToExercise(newlyAddedTag.value, exercise);
+                TagService.delTagFromExercise(newlyAddedTag.value, exercise);
+                //Remove the unused tag from the module ...
+                TagService.delTagFromModule(module.value, toBeEditedTag);
+                //... but add the new one to it
+                TagService.addTagToModule(module.value, newlyAddedTag.value);
+              }
+            })
+          })
+        })
+      });
+    }
+  })
+  //TagService.editTag(toBeEditedTag);
 }
 
 function removeTag(tag: Tag): void {
-  //No way to delete tags globally
-  exercises.value.forEach((ex) => {
-    TagService.delTagFromExercise(tag, ex).then(() => getCurrentTags());
-  });
+  TagService.delTagFromModule(module.value, tag).then(() => getCurrentTags());
+  ExerciseService.getExercisesForModule(module.value.module_id).then(res => {
+    const resData = res.data;
+    resData.forEach((ex: Exercise) => {
+      ex.tags.forEach((exTag: Tag) => {
+        if(exTag.tag_id == tag.tag_id) {
+          TagService.delTagFromExercise(tag, ex);
+        }
+      })
+    });
+  })
 }
 
 function setUserRole(user: ModuleUser, role: string): void {

--- a/src/components/ModuleManager.vue
+++ b/src/components/ModuleManager.vue
@@ -17,22 +17,19 @@
             <span v-html="$t('buttons.back')" />
           </v-tooltip>
         </v-col>
-        <v-col cols="5">
+        <v-col cols="7">
           <v-card-title> {{ module.name }}</v-card-title>
         </v-col>
-        <v-col cols="3">
-          <v-row justify="end">
-            <v-btn
+        <v-col cols="4" align-self="center">
+          <v-row>
+            <v-btn 
+            style="margin-right: 1em"
             @click="changeVisibility(module)">
-              <v-icon size="large" :icon="lock.value"></v-icon>
+              <v-icon size="large" :icon="lock.value" :color="lock.color"></v-icon>
             </v-btn>
-          </v-row>
-        </v-col>
-        <v-col cols="3">
-          <v-row justify="end">
-          <v-btn @click="manageTagsDialog.show = true">
-            {{ $t("module_manager.edit_tag_button") }}
-          </v-btn>
+            <v-btn @click="manageTagsDialog.show = true">
+              {{ $t("module_manager.edit_tag_button") }}
+            </v-btn>
           </v-row>
         </v-col>
       </v-row>
@@ -297,6 +294,7 @@ const filteredUsers: Ref<User[]> = ref([]);
 const tagsCurrent: Ref<Tag[]> = ref([]);
 const lock = ref({
   value: "mdi-lock",
+  color: "error"
 });
 
 defineProps<{
@@ -312,6 +310,7 @@ async function loadModule(): Promise<void> {
     .then((res) => {
       module.value = res.data;
       module.value.modulePublic ? lock.value.value = 'mdi-lock-open' : lock.value.value = 'mdi-lock';
+      module.value.modulePublic ? lock.value.color = 'success' : lock.value.color = 'error';
     })
     .then(() => {
       loadAllUsers().then(() => {
@@ -402,10 +401,11 @@ const editPrivilegeDialog = ref({
 }>;
 
 function getCurrentTags(): void {
-  TagService.getModuleTags(module.value).then((res) => {
-    tagsCurrent.value = res.data;
-    //console.log(tagsCurrent.value);
-  });
+  TagService.getModuleTags(module.value).then(res => {
+    const filteredTags: Ref<Tag[]> = ref([]);
+    res.data.forEach((tag: Tag) => filteredTags.value.map(t => t.tag_id).includes(tag.tag_id) ? 'nothing' : filteredTags.value.push(tag));
+    tagsCurrent.value = filteredTags.value;
+  })
 }
 
 function editTag(toBeEditedTag: Tag): void {
@@ -495,6 +495,7 @@ function changeVisibility(module: Module) {
   const changedModule: Ref<Module> = ref(module);
   changedModule.value.modulePublic = !changedModule.value.modulePublic;
   changedModule.value.modulePublic ? lock.value.value = 'mdi-lock-open' : lock.value.value = 'mdi-lock';
+  changedModule.value.modulePublic ? lock.value.color = 'success' : lock.value.color = 'error';
   ModuleService.editModule(changedModule.value);
 }
 </script>

--- a/src/components/ModuleManager.vue
+++ b/src/components/ModuleManager.vue
@@ -2,7 +2,7 @@
   <v-container>
     <v-card v-if="!embedded">
       <v-row>
-        <v-col cols="2" align-self="center">
+        <v-col cols="1" align-self="center">
           <v-tooltip bottom>
             <template v-slot:activator="{ props: tooltip3 }">
               <v-btn
@@ -17,13 +17,23 @@
             <span v-html="$t('buttons.back')" />
           </v-tooltip>
         </v-col>
-        <v-col cols="8">
+        <v-col cols="5">
           <v-card-title> {{ module.name }}</v-card-title>
         </v-col>
-        <v-col cols="2">
+        <v-col cols="3">
+          <v-row justify="end">
+            <v-btn
+            @click="changeVisibility(module)">
+              <v-icon size="large" :icon="lock.value"></v-icon>
+            </v-btn>
+          </v-row>
+        </v-col>
+        <v-col cols="3">
+          <v-row justify="end">
           <v-btn @click="manageTagsDialog.show = true">
             {{ $t("module_manager.edit_tag_button") }}
           </v-btn>
+          </v-row>
         </v-col>
       </v-row>
     </v-card>
@@ -126,8 +136,7 @@
             <tbody>
               <tr v-for="tag in tagsCurrent" v-bind:key="tag.tag_id">
                 <td class="text-center">
-                  <v-icon size="small" :icon="tag.icon.reference"/>
-
+                  <v-icon size="small" :icon="tag.icon.reference" />
                 </td>
                 <td>
                   <v-container class="test-class">
@@ -286,7 +295,9 @@ const moduleUsers: Ref<ModuleUser[]> = ref([]);
 const allUsers: Ref<ModuleUser[]> = ref([]);
 const filteredUsers: Ref<User[]> = ref([]);
 const tagsCurrent: Ref<Tag[]> = ref([]);
-const exercises: Ref<Exercise[]> = ref([]);
+const lock = ref({
+  value: "mdi-lock",
+});
 
 defineProps<{
   embedded?: boolean;
@@ -300,6 +311,7 @@ async function loadModule(): Promise<void> {
   )
     .then((res) => {
       module.value = res.data;
+      module.value.modulePublic ? lock.value.value = 'mdi-lock-open' : lock.value.value = 'mdi-lock';
     })
     .then(() => {
       loadAllUsers().then(() => {
@@ -477,6 +489,13 @@ function setUserRole(user: ModuleUser, role: string): void {
     user.module_role = res.data.find((a: Role) => a.name == role);
     ModuleService.editModuleUser(module.value, user); // intentionally not awaited, api does not update user role}
   });
+}
+
+function changeVisibility(module: Module) {
+  const changedModule: Ref<Module> = ref(module);
+  changedModule.value.modulePublic = !changedModule.value.modulePublic;
+  changedModule.value.modulePublic ? lock.value.value = 'mdi-lock-open' : lock.value.value = 'mdi-lock';
+  ModuleService.editModule(changedModule.value);
 }
 </script>
 

--- a/src/components/ModuleManager.vue
+++ b/src/components/ModuleManager.vue
@@ -383,6 +383,7 @@ function editTag(toBeEditedTag: Tag): void {
           res.data.forEach((exercise: Exercise) => {
             exercise.tags.forEach((exerciseTag: Tag) => {
               if(exerciseTag.tag_id == toBeEditedTag.tag_id) {
+                tagFound = true;
                 TagService.addTagToExercise(foundTag, exercise);
                 TagService.delTagFromExercise(exerciseTag, exercise);
                 TagService.delTagFromModule(module.value, toBeEditedTag);
@@ -398,35 +399,65 @@ function editTag(toBeEditedTag: Tag): void {
       const newTag = {
         tag_id: 0,
         name: toBeEditedTag.name,
+        icon: {
+          icon_id: 5,
+          reference: "mdi-laptop"
+        }
       };
-      //Add tag globally
       TagService.addTag(newTag).then(() => {
-        //Get the newly added tag
-        const newlyAddedTag: Ref<Tag> = ref({}) as Ref<Tag>
-        TagService.getAllTags().then(res => {
-          res.data.forEach((allTag: Tag) => {
-            if(allTag.name.toLowerCase() == newTag.name.toLowerCase()) newlyAddedTag.value = allTag
-          })
-        })
-        //Get all exercises
-        ExerciseService.getExercisesForModule(module.value.module_id).then(res => {
-          //For each exercise ...
-          res.data.forEach((exercise: Exercise) => {
-            //... there are tags of whitch ...
-            exercise.tags.forEach((exerciseTag: Tag) => {
-              //... a tag is found that has to be replaced because it still is the toBeEditedTag
-              if(exerciseTag.tag_id == toBeEditedTag.tag_id) {
-                TagService.addTagToExercise(newlyAddedTag.value, exercise);
-                TagService.delTagFromExercise(newlyAddedTag.value, exercise);
-                //Remove the unused tag from the module ...
-                TagService.delTagFromModule(module.value, toBeEditedTag);
-                //... but add the new one to it
-                TagService.addTagToModule(module.value, newlyAddedTag.value);
-              }
+      TagService.getAllTags().then((res) => {
+        res.data.forEach((allTag: Tag) => {
+          if(allTag.name.toLowerCase() == newTag.name.toLowerCase()) {
+            console.log(allTag);
+            ExerciseService.getExercisesForModule(module.value.module_id).then(res => {
+            res.data.forEach((exercise: Exercise) => {
+                exercise.tags.forEach((exTag: Tag) => {
+                  if(exTag.tag_id == toBeEditedTag.tag_id) {
+                    TagService.addTagToExercise(allTag, exercise);
+                    TagService.delTagFromExercise(exTag, exercise);
+                    TagService.addTagToModule(module.value, allTag);
+                    TagService.delTagFromModule(module.value, exTag);
+                  }
+                })
+              })
             })
-          })
-        })
-      });
+          }
+        });
+      })
+        
+      })
+      //Add tag globally
+      //TagService.addTag(newTag).then(() => {
+      
+        
+      //});
+      // // TagService.addTag(newTag).then(() => {
+      // //   //Get the newly added tag
+      // //   const newlyAddedTag: Ref<Tag> = ref({}) as Ref<Tag>
+      // //   TagService.getAllTags().then(res => {
+      // //     res.data.forEach((allTag: Tag) => {
+      // //       if(allTag.name.toLowerCase() == newTag.name.toLowerCase()) newlyAddedTag.value = allTag
+      // //     })
+      // //   })
+      //   //Get all exercises
+      //   ExerciseService.getExercisesForModule(module.value.module_id).then(res => {
+      //     //For each exercise ...
+      //     res.data.forEach((exercise: Exercise) => {
+      //       //... there are tags of whitch ...
+      //       exercise.tags.forEach((exerciseTag: Tag) => {
+      //         //... a tag is found that has to be replaced because it still is the toBeEditedTag
+      //         if(exerciseTag.tag_id == toBeEditedTag.tag_id) {
+      //           TagService.addTagToExercise(newlyAddedTag.value, exercise);
+      //           TagService.delTagFromExercise(newlyAddedTag.value, exercise);
+      //           //Remove the unused tag from the module ...
+      //           TagService.delTagFromModule(module.value, toBeEditedTag);
+      //           //... but add the new one to it
+      //           TagService.addTagToModule(module.value, newlyAddedTag.value);
+      //         }
+      //       })
+      //     })
+      //   })
+      // });
     }
   })
   //TagService.editTag(toBeEditedTag);

--- a/src/components/ModuleManager.vue
+++ b/src/components/ModuleManager.vue
@@ -120,10 +120,15 @@
                   {{ $t("module_manager.tag") }}
                 </th>
                 <th class="hide-btn-behind-header"></th>
+                <th class="hide-btn-behind-header"></th>
               </tr>
             </thead>
             <tbody>
               <tr v-for="tag in tagsCurrent" v-bind:key="tag.tag_id">
+                <td class="text-center">
+                  <v-icon size="small" :icon="tag.icon.reference"/>
+
+                </td>
                 <td>
                   <v-container class="test-class">
                     <v-text-field

--- a/src/components/ModuleManager.vue
+++ b/src/components/ModuleManager.vue
@@ -5,11 +5,16 @@
         <v-col cols="2" align-self="center">
           <v-tooltip bottom>
             <template v-slot:activator="{ props: tooltip3 }">
-              <v-btn v-bind="tooltip3" @click="goBack()" class="back-button" rounded="false">
-                <v-icon icon="mdi-arrow-left"/>
+              <v-btn
+                v-bind="tooltip3"
+                @click="goBack()"
+                class="back-button"
+                rounded="false"
+              >
+                <v-icon icon="mdi-arrow-left" />
               </v-btn>
             </template>
-            <span v-html="$t('buttons.back')"/>
+            <span v-html="$t('buttons.back')" />
           </v-tooltip>
         </v-col>
         <v-col cols="8">
@@ -22,70 +27,73 @@
         </v-col>
       </v-row>
     </v-card>
-    <br>
-    <v-btn @click="manageTagsDialog.show = true" v-if="embedded" class="embeddedEditTagsButton">
+    <br />
+    <v-btn
+      @click="manageTagsDialog.show = true"
+      v-if="embedded"
+      class="embeddedEditTagsButton"
+    >
       {{ $t("module_manager.edit_tag_button") }}
     </v-btn>
-    <br>
-    <br/>
+    <br />
+    <br />
     <v-card>
       <v-row>
         <v-col cols="12">
           <v-table>
             <thead>
-            <tr>
-              <th class="text-left">{{ $t("module_manager.name") }}</th>
-              <th class="text-left">{{ $t("module_manager.roles") }}</th>
-              <th class="text-right"></th>
-              <th class="text-right"></th>
-            </tr>
+              <tr>
+                <th class="text-left">{{ $t("module_manager.name") }}</th>
+                <th class="text-left">{{ $t("module_manager.roles") }}</th>
+                <th class="text-right"></th>
+                <th class="text-right"></th>
+              </tr>
             </thead>
             <tbody>
-            <tr v-for="user in moduleUsers" v-bind:key="user.user_id">
-              <td class="text-left">{{ user.name }}</td>
-              <td class="text-left">{{ user.module_role.name }}</td>
-              <td class="placeholder-td"></td>
-              <td class="text-right">
-                <v-tooltip top>
-                  <template v-slot:activator="{ props: tooltip }">
-                    <v-btn
+              <tr v-for="user in moduleUsers" v-bind:key="user.user_id">
+                <td class="text-left">{{ user.name }}</td>
+                <td class="text-left">{{ user.module_role.name }}</td>
+                <td class="placeholder-td"></td>
+                <td class="text-right">
+                  <v-tooltip top>
+                    <template v-slot:activator="{ props: tooltip }">
+                      <v-btn
                         @click="
-                      editPrivilegeDialog.show = true;
-                      editPrivilegeDialog.userRole = user.module_role.name;
-                      editPrivilegeDialog.user = user;
-                    "
+                          editPrivilegeDialog.show = true;
+                          editPrivilegeDialog.userRole = user.module_role.name;
+                          editPrivilegeDialog.user = user;
+                        "
                         class="manage-button"
                         color="primary"
                         v-bind="tooltip"
-                    >
-                      <v-icon icon="mdi-cog"></v-icon>
-                    </v-btn>
-                  </template>
-                  <span v-html="$t('module_manager.edit_privilege')"/>
-                </v-tooltip>
-                <v-tooltip top>
-                  <template v-slot:activator="{ props: tooltip2 }">
-                    <v-btn
+                      >
+                        <v-icon icon="mdi-cog"></v-icon>
+                      </v-btn>
+                    </template>
+                    <span v-html="$t('module_manager.edit_privilege')" />
+                  </v-tooltip>
+                  <v-tooltip top>
+                    <template v-slot:activator="{ props: tooltip2 }">
+                      <v-btn
                         class="manage-button"
                         @click="deleteModuleUser(user)"
                         color="error"
                         v-bind="tooltip2"
-                    >
-                      <v-icon icon="mdi-delete"></v-icon>
-                    </v-btn>
-                  </template>
-                  <span v-html="$t('buttons.remove')"/>
-                </v-tooltip>
-
-              </td>
-            </tr>
+                      >
+                        <v-icon icon="mdi-delete"></v-icon>
+                      </v-btn>
+                    </template>
+                    <span v-html="$t('buttons.remove')" />
+                  </v-tooltip>
+                </td>
+              </tr>
             </tbody>
           </v-table>
           <v-btn
-              class="add-user-btn"
-              @click="manageUsersDialog.show = true"
-              color="secondary"
-              v-html="$t('module_manager.add_user')"
+            class="add-user-btn"
+            @click="manageUsersDialog.show = true"
+            color="secondary"
+            v-html="$t('module_manager.add_user')"
           />
         </v-col>
         <v-col cols="12">
@@ -95,170 +103,175 @@
     </v-card>
 
     <!-- Edit tags dialog start -->
-      <!-- [Desktop] -->
+    <!-- [Desktop] -->
     <v-dialog
-        class="d-none d-md-flex"
-        v-model="manageTagsDialog.show"
-        :retain-focus="false"
-        transition="slide-y-transition"
+      class="d-none d-md-flex"
+      v-model="manageTagsDialog.show"
+      :retain-focus="false"
+      transition="slide-y-transition"
     >
       <v-card top="20%" width="50vw">
         <v-card-title> {{ $t("module_manager.edit_tag") }}</v-card-title>
         <v-card-text>
           <v-table fixed-header height="400px">
             <thead>
-            <tr>
-              <th class="hide-btn-behind-header">{{ $t("module_manager.tag") }}</th>
-              <th class="hide-btn-behind-header"></th>
-            </tr>
+              <tr>
+                <th class="hide-btn-behind-header">
+                  {{ $t("module_manager.tag") }}
+                </th>
+                <th class="hide-btn-behind-header"></th>
+              </tr>
             </thead>
             <tbody>
-            <tr v-for="tag in tagsCurrent" v-bind:key="tag.tag_id">
-              <td>
-                <v-container class="test-class">
-                  <v-text-field
+              <tr v-for="tag in tagsCurrent" v-bind:key="tag.tag_id">
+                <td>
+                  <v-container class="test-class">
+                    <v-text-field
                       vertical-align="middle"
                       class="centered-input extend"
                       v-model="tag.name"
-                  />
-                </v-container>
-              </td>
-              <td class="text-right">
-                <v-btn
+                    />
+                  </v-container>
+                </td>
+                <td class="text-right">
+                  <v-btn
                     class="manage-button"
                     @click="editTag(tag)"
                     color="primary"
-                >
-                  <v-icon icon="mdi-content-save"></v-icon>
-                </v-btn>
-                <v-btn
+                  >
+                    <v-icon icon="mdi-content-save"></v-icon>
+                  </v-btn>
+                  <v-btn
                     class="manage-button"
                     @click="removeTag(tag)"
                     color="error"
-                >
-                  <v-icon icon="mdi-delete"></v-icon>
-                </v-btn>
-              </td>
-            </tr>
+                  >
+                    <v-icon icon="mdi-delete"></v-icon>
+                  </v-btn>
+                </td>
+              </tr>
             </tbody>
           </v-table>
         </v-card-text>
         <v-card-actions>
           <v-btn
-              @click="manageTagsDialog.show = false"
-              color="error"
-              v-html="$t('buttons.close')"
+            @click="manageTagsDialog.show = false"
+            color="error"
+            v-html="$t('buttons.close')"
           />
         </v-card-actions>
       </v-card>
     </v-dialog>
-      <!-- [Desktop] -->
+    <!-- [Desktop] -->
     <!-- Edit tags dialog end -->
 
     <!-- Edit users dialog start -->
-      <!-- [Desktop] -->
+    <!-- [Desktop] -->
     <v-dialog
-        class="d-none d-md-flex"
-        v-model="editPrivilegeDialog.show"
-        :retain-focus="false"
-        transition="slide-y-transition"
+      class="d-none d-md-flex"
+      v-model="editPrivilegeDialog.show"
+      :retain-focus="false"
+      transition="slide-y-transition"
     >
       <v-card top="15%" width="50vw">
         <v-card-title> {{ $t("module_manager.edit_privilege") }}</v-card-title>
         <v-card-text>
           <v-radio-group v-model="editPrivilegeDialog.userRole">
             <v-radio
-                :label="$t('module_manager.student')"
-                :key="1"
-                value="student"
+              :label="$t('module_manager.student')"
+              :key="1"
+              value="student"
             />
             <v-radio
-                :label="$t('module_manager.tutor')"
-                value="tutor"
-                :key="2"
+              :label="$t('module_manager.tutor')"
+              value="tutor"
+              :key="2"
             />
             <v-radio
-                :label="$t('module_manager.teacher')"
-                value="teacher"
-                :key="3"
+              :label="$t('module_manager.teacher')"
+              value="teacher"
+              :key="3"
             />
           </v-radio-group>
         </v-card-text>
         <v-card-actions>
           <v-btn
-              @click="
+            @click="
               editPrivilegeDialog.show = false;
               editPrivilegeDialog.userRole = null;
               editPrivilegeDialog.user = null;
             "
-              color="error"
-              v-html="$t('buttons.close')"
+            color="error"
+            v-html="$t('buttons.close')"
           />
           <v-btn
-              @click="
+            @click="
               editPrivilegeDialog.show = false;
-              setUserRole(editPrivilegeDialog.user, editPrivilegeDialog.userRole);
+              setUserRole(
+                editPrivilegeDialog.user,
+                editPrivilegeDialog.userRole
+              );
             "
-              color="primary"
-              v-html="$t('buttons.save')"
+            color="primary"
+            v-html="$t('buttons.save')"
           />
         </v-card-actions>
       </v-card>
     </v-dialog>
-      <!-- [Desktop] -->
+    <!-- [Desktop] -->
     <!-- Edit users dialog end -->
 
     <!-- Edit users dialog start -->
-      <!-- [Desktop] -->
+    <!-- [Desktop] -->
     <v-dialog
-        class="d-none d-md-flex"
-        v-model="manageUsersDialog.show"
-        :retain-focus="false"
-        transition="slide-y-transition"
+      class="d-none d-md-flex"
+      v-model="manageUsersDialog.show"
+      :retain-focus="false"
+      transition="slide-y-transition"
     >
       <v-card top="20%" width="50vw">
         <v-card-title> {{ $t("module_manager.add_user") }}</v-card-title>
         <v-table fixed-header height="400px">
           <thead>
-          <tr>
-            <th>{{ $t("module_manager.name") }}</th>
-            <th class="hide-btn-behind-header"></th>
-          </tr>
+            <tr>
+              <th>{{ $t("module_manager.name") }}</th>
+              <th class="hide-btn-behind-header"></th>
+            </tr>
           </thead>
           <tbody>
-          <tr v-for="user in filteredUsers" v-bind:key="user.user_id">
-            <td>{{ user.name }}</td>
-            <td class="text-right">
-              <v-btn @click="addModuleUser(user.user_id)" color="primary">
-                <v-icon icon="mdi-account-plus"></v-icon>
-              </v-btn>
-            </td>
-          </tr>
+            <tr v-for="user in filteredUsers" v-bind:key="user.user_id">
+              <td>{{ user.name }}</td>
+              <td class="text-right">
+                <v-btn @click="addModuleUser(user.user_id)" color="primary">
+                  <v-icon icon="mdi-account-plus"></v-icon>
+                </v-btn>
+              </td>
+            </tr>
           </tbody>
         </v-table>
         <v-card-actions>
           <v-btn
-              @click="manageUsersDialog.show = false"
-              color="error"
-              v-html="$t('buttons.close')"
+            @click="manageUsersDialog.show = false"
+            color="error"
+            v-html="$t('buttons.close')"
           />
         </v-card-actions>
       </v-card>
     </v-dialog>
-      <!-- [Desktop] -->
+    <!-- [Desktop] -->
     <!-- Edit users dialog end -->
   </v-container>
 </template>
 
 <script setup lang="ts">
-import {onBeforeMount, Ref, ref} from "vue";
-import {useRoute, useRouter} from "vue-router";
+import { onBeforeMount, Ref, ref } from "vue";
+import { useRoute, useRouter } from "vue-router";
 import UserService from "@/services/UserService";
 import ModuleService from "@/services/ModuleService";
 import TagService from "@/services/TagService";
 import ExerciseService from "@/services/ExerciseService";
-import {Exercise, Module, ModuleUser, Role, Tag, User} from "@/helpers/types";
-import {defineProps} from "vue";
+import { Exercise, Module, ModuleUser, Role, Tag, User } from "@/helpers/types";
+import { defineProps } from "vue";
 
 //Router
 const route = useRoute();
@@ -271,40 +284,45 @@ const tagsCurrent: Ref<Tag[]> = ref([]);
 const exercises: Ref<Exercise[]> = ref([]);
 
 defineProps<{
-  embedded?: boolean
-}>()
+  embedded?: boolean;
+}>();
 
 async function loadModule(): Promise<void> {
-  ModuleService.getModule(route.params.module instanceof Array ? route.params.module[0] : route.params.module).then((res) => {
-    module.value = res.data;
-  }).then(() => {
-    loadAllUsers().then(() => {
-      loadFilteredUsers();
+  ModuleService.getModule(
+    route.params.module instanceof Array
+      ? route.params.module[0]
+      : route.params.module
+  )
+    .then((res) => {
+      module.value = res.data;
+    })
+    .then(() => {
+      loadAllUsers().then(() => {
+        loadFilteredUsers();
+      });
+      loadModuleUsers();
+      getCurrentTags();
     });
-    loadModuleUsers();
-    getCurrentTags();
-  });
 }
 
 async function loadModuleUsers(): Promise<void> {
   moduleUsers.value = (
-      await ModuleService.getModuleUsers(module.value)
+    await ModuleService.getModuleUsers(module.value)
   ).data.sort((a: ModuleUser, b: ModuleUser) => a.user_id - b.user_id);
 }
 
 async function loadAllUsers(): Promise<void> {
-  allUsers.value = (await UserService.getUsers())
-      .data.sort(
-          (a: ModuleUser, b: ModuleUser) => a.user_id - b.user_id
-      );
+  allUsers.value = (await UserService.getUsers()).data.sort(
+    (a: ModuleUser, b: ModuleUser) => a.user_id - b.user_id
+  );
 }
 
 async function loadFilteredUsers(): Promise<void> {
   filteredUsers.value = allUsers.value
-      .map(({user_id, name}) => ({user_id, name}))
-      .filter(
-          (a) => !moduleUsers.value.map((b) => b.user_id).includes(a.user_id)
-      ) as User[];
+    .map(({ user_id, name }) => ({ user_id, name }))
+    .filter(
+      (a) => !moduleUsers.value.map((b) => b.user_id).includes(a.user_id)
+    ) as User[];
 }
 
 onBeforeMount(async () => {
@@ -321,14 +339,14 @@ function addModuleUser(number: number): void {
   moduleUser.value.username = user.value.username;
   moduleUser.value.email = user.value.email;
   ModuleService.addModuleUser(module.value, moduleUser.value)
-      .then(() => loadModuleUsers())
-      .then(() => loadFilteredUsers());
+    .then(() => loadModuleUsers())
+    .then(() => loadFilteredUsers());
 }
 
 function deleteModuleUser(user: ModuleUser): void {
   ModuleService.delModuleUser(module.value, user)
-      .then(() => loadModuleUsers())
-      .then(() => loadFilteredUsers());
+    .then(() => loadModuleUsers())
+    .then(() => loadFilteredUsers());
 }
 
 function getUserTemplate(): ModuleUser {
@@ -367,119 +385,91 @@ const editPrivilegeDialog = ref({
 }>;
 
 function getCurrentTags(): void {
-  TagService.getModuleTags(module.value).then(res => {
+  TagService.getModuleTags(module.value).then((res) => {
     tagsCurrent.value = res.data;
     //console.log(tagsCurrent.value);
-  })
+  });
 }
 
 function editTag(toBeEditedTag: Tag): void {
-  TagService.getAllTags().then(res => {
+  TagService.getAllTags().then((res) => {
     let tagFound = false;
     res.data.forEach((foundTag: Tag) => {
       //If find tag already exists with the new name
-      if(foundTag.name.toLowerCase() == toBeEditedTag.name.toLowerCase()) {
-        ExerciseService.getExercisesForModule(module.value.module_id).then(res => {
-          res.data.forEach((exercise: Exercise) => {
-            exercise.tags.forEach((exerciseTag: Tag) => {
-              if(exerciseTag.tag_id == toBeEditedTag.tag_id) {
-                tagFound = true;
-                TagService.addTagToExercise(foundTag, exercise);
-                TagService.delTagFromExercise(exerciseTag, exercise);
-                TagService.delTagFromModule(module.value, toBeEditedTag);
-                console.log(TagService.addTagToModule(module.value, foundTag));
-              }
-            })
-          })
-        })
+      if (foundTag.name.toLowerCase() == toBeEditedTag.name.toLowerCase()) {
+        ExerciseService.getExercisesForModule(module.value.module_id).then(
+          (res) => {
+            res.data.forEach((exercise: Exercise) => {
+              exercise.tags.forEach((exerciseTag: Tag) => {
+                if (exerciseTag.tag_id == toBeEditedTag.tag_id) {
+                  tagFound = true;
+                  TagService.addTagToExercise(foundTag, exercise);
+                  TagService.delTagFromExercise(exerciseTag, exercise);
+                  TagService.delTagFromModule(module.value, toBeEditedTag);
+                  console.log(
+                    TagService.addTagToModule(module.value, foundTag)
+                  );
+                }
+              });
+            });
+          }
+        );
       }
-    })
+    });
     //There is no other tag with the same name
-    if(!tagFound) {
+    if (!tagFound) {
       const newTag = {
         tag_id: 0,
         name: toBeEditedTag.name,
         icon: {
           icon_id: 5,
-          reference: "mdi-laptop"
-        }
+          reference: "mdi-laptop",
+        },
       };
       TagService.addTag(newTag).then(() => {
-      TagService.getAllTags().then((res) => {
-        res.data.forEach((allTag: Tag) => {
-          if(allTag.name.toLowerCase() == newTag.name.toLowerCase()) {
-            console.log(allTag);
-            ExerciseService.getExercisesForModule(module.value.module_id).then(res => {
-            res.data.forEach((exercise: Exercise) => {
-                exercise.tags.forEach((exTag: Tag) => {
-                  if(exTag.tag_id == toBeEditedTag.tag_id) {
-                    TagService.addTagToExercise(allTag, exercise);
-                    TagService.delTagFromExercise(exTag, exercise);
-                    TagService.addTagToModule(module.value, allTag);
-                    TagService.delTagFromModule(module.value, exTag);
-                  }
-                })
-              })
-            })
-          }
+        TagService.getAllTags().then((res) => {
+          res.data.forEach((allTag: Tag) => {
+            if (allTag.name.toLowerCase() == newTag.name.toLowerCase()) {
+              console.log(allTag);
+              ExerciseService.getExercisesForModule(
+                module.value.module_id
+              ).then((res) => {
+                res.data.forEach((exercise: Exercise) => {
+                  exercise.tags.forEach((exTag: Tag) => {
+                    if (exTag.tag_id == toBeEditedTag.tag_id) {
+                      TagService.addTagToExercise(allTag, exercise);
+                      TagService.delTagFromExercise(exTag, exercise);
+                      TagService.addTagToModule(module.value, allTag);
+                      TagService.delTagFromModule(module.value, exTag);
+                    }
+                  });
+                });
+              });
+            }
+          });
         });
-      })
-        
-      })
-      //Add tag globally
-      //TagService.addTag(newTag).then(() => {
-      
-        
-      //});
-      // // TagService.addTag(newTag).then(() => {
-      // //   //Get the newly added tag
-      // //   const newlyAddedTag: Ref<Tag> = ref({}) as Ref<Tag>
-      // //   TagService.getAllTags().then(res => {
-      // //     res.data.forEach((allTag: Tag) => {
-      // //       if(allTag.name.toLowerCase() == newTag.name.toLowerCase()) newlyAddedTag.value = allTag
-      // //     })
-      // //   })
-      //   //Get all exercises
-      //   ExerciseService.getExercisesForModule(module.value.module_id).then(res => {
-      //     //For each exercise ...
-      //     res.data.forEach((exercise: Exercise) => {
-      //       //... there are tags of whitch ...
-      //       exercise.tags.forEach((exerciseTag: Tag) => {
-      //         //... a tag is found that has to be replaced because it still is the toBeEditedTag
-      //         if(exerciseTag.tag_id == toBeEditedTag.tag_id) {
-      //           TagService.addTagToExercise(newlyAddedTag.value, exercise);
-      //           TagService.delTagFromExercise(newlyAddedTag.value, exercise);
-      //           //Remove the unused tag from the module ...
-      //           TagService.delTagFromModule(module.value, toBeEditedTag);
-      //           //... but add the new one to it
-      //           TagService.addTagToModule(module.value, newlyAddedTag.value);
-      //         }
-      //       })
-      //     })
-      //   })
-      // });
+      });
     }
-  })
-  //TagService.editTag(toBeEditedTag);
+  });
 }
 
 function removeTag(tag: Tag): void {
   TagService.delTagFromModule(module.value, tag).then(() => getCurrentTags());
-  ExerciseService.getExercisesForModule(module.value.module_id).then(res => {
+  ExerciseService.getExercisesForModule(module.value.module_id).then((res) => {
     const resData = res.data;
     resData.forEach((ex: Exercise) => {
       ex.tags.forEach((exTag: Tag) => {
-        if(exTag.tag_id == tag.tag_id) {
+        if (exTag.tag_id == tag.tag_id) {
           TagService.delTagFromExercise(tag, ex);
         }
-      })
+      });
     });
-  })
+  });
 }
 
 function setUserRole(user: ModuleUser, role: string): void {
   UserService.getRoles().then((res) => {
-    user.module_role = res.data.find((a: Role) => a.name == role)
+    user.module_role = res.data.find((a: Role) => a.name == role);
     ModuleService.editModuleUser(module.value, user); // intentionally not awaited, api does not update user role}
   });
 }
@@ -514,7 +504,7 @@ function setUserRole(user: ModuleUser, role: string): void {
   z-index: 1;
 }
 
-.embeddedEditTagsButton{
+.embeddedEditTagsButton {
   margin-right: auto;
   margin-left: auto;
   display: block;

--- a/src/components/ModuleManager.vue
+++ b/src/components/ModuleManager.vue
@@ -22,8 +22,7 @@
         </v-col>
         <v-col cols="4" align-self="center">
           <v-row>
-            <v-btn 
-            style="margin-right: 1em"
+            <v-btn class="mr-4 mb-2 ml-0"
             @click="changeVisibility(module)">
               <v-icon size="large" :icon="lock.value" :color="lock.color"></v-icon>
             </v-btn>
@@ -120,7 +119,7 @@
       <v-card top="20%" width="50vw">
         <v-card-title> {{ $t("module_manager.edit_tag") }}</v-card-title>
         <v-card-text>
-          <v-table fixed-header height="400px">
+          <v-table :fixed-header="true" height="400px">
             <thead>
               <tr>
                 <th class="hide-btn-behind-header">
@@ -242,7 +241,7 @@
     >
       <v-card top="20%" width="50vw">
         <v-card-title> {{ $t("module_manager.add_user") }}</v-card-title>
-        <v-table fixed-header height="400px">
+        <v-table :fixed-header="true" height="400px">
           <thead>
             <tr>
               <th>{{ $t("module_manager.name") }}</th>

--- a/src/components/admin/ModuleManagement.vue
+++ b/src/components/admin/ModuleManagement.vue
@@ -449,6 +449,11 @@ function getModuleTemplate(): Module {
     module_id: 0,
     name: "",
     description: "",
+    modulePublic: false,
+    icon: {
+      icon_id: 7,
+      reference: 'mdi-animation'
+    }
   };
 }
 </script>

--- a/src/components/exercises/ExerciseCard.vue
+++ b/src/components/exercises/ExerciseCard.vue
@@ -129,9 +129,10 @@
           <span>Feedback ansehen</span>
         </v-tooltip-->
         <v-chip
-        v-for="t in tags"
-        v-bind:key="t.id">
-          {{ t.name }}
+        v-for="tag in tags"
+        v-bind:key="tag.id">
+          <v-icon class="tag-icon" size=small :icon="tag.icon.reference"/>
+          {{ tag.name }}
         </v-chip>
       </div>
       <div>
@@ -188,6 +189,7 @@ import MarkdownModal from "@/components/helpers/MarkdownModal.vue";
 import {onBeforeMount, Ref, ref} from "vue";
 import ExerciseService from "@/services/ExerciseService";
 import UserService from "@/services/UserService";
+import TagService from "@/services/TagService";
 import {Exercise, User, Tag} from "@/helpers/types";
 
 const route = useRoute();
@@ -207,7 +209,7 @@ onBeforeMount(async () => {
   ExerciseService.getExercise(id).then(async (res) => {
     exercise.value = res.data;
     await router.replace(`/${exercise.value.module.module_id}/e/${id}`)
-    tags.value = exercise.value.tags;
+    getAllExerciseTags();
     document.title = exercise.value.module.name + ' - ' + exercise.value.title
   }).catch(() => {
     router.replace("/page-not-found")
@@ -228,6 +230,13 @@ function goToSubmission() {
 
 function goToSubmissionsList() {
   router.push(`/${exercise.value.module.module_id}/eval/${id}`);
+}
+
+function getAllExerciseTags(): void {
+  TagService.getTagsFromExercise(exercise.value).then(res => {
+    console.log(res.data);
+    tags.value = res.data;
+  })
 }
 
 /*
@@ -257,4 +266,7 @@ let hasSubmission = true;
 </script>
 
 <style scoped>
+.tag-icon {
+  margin-right: 0.3em;
+}
 </style>

--- a/src/components/exercises/ExerciseEditor.vue
+++ b/src/components/exercises/ExerciseEditor.vue
@@ -588,6 +588,10 @@ function getTagTemplate(): Tag {
   return {
     tag_id: 0,
     name: "",
+    icon: {
+      icon_id: 5,
+      reference: "mdi-laptop"
+    }
   };
 }
 </script>

--- a/src/components/exercises/ExerciseEditor.vue
+++ b/src/components/exercises/ExerciseEditor.vue
@@ -146,62 +146,6 @@
     </v-dialog>
     <!-- [Desktop] Edit tags dialog end -->
 
-    <!-- [Mobile] Add tags dialog start -->
-    <v-dialog
-        class="d-md-none"
-        v-model="addTagsDialog.show"
-        :retain-focus="false"
-        transition="slide-y-transition"
-    >
-      <v-card top="20%" width="90vw">
-        <v-card-title> {{ $t("exercise.tag_add_desc") }}</v-card-title>
-        <v-table :fixed-header="true" height="400px">
-          <thead>
-          <tr>
-            <th>{{ $t("exercise.tag") }}</th>
-            <th class="hide-btn-behind-header"></th>
-          </tr>
-          </thead>
-          <tbody>
-          <tr v-for="tag in filteredTags" :key="tag.tag_id">
-            <td>
-              {{ tag.name }}
-            </td>
-            <td class="text-right">
-              <v-btn @click="addTagToExercise(tag)" color="primary">
-                <v-icon icon="mdi-plus"></v-icon>
-              </v-btn>
-            </td>
-          </tr>
-          </tbody>
-        </v-table>
-        <v-row>
-          <v-col cols="9">
-            <v-text-field
-                :label="$t('exercise.tag_search_or_create')"
-                v-model="addTagsDialog.target.name"
-                @input="updateFilterList">
-            </v-text-field>
-          </v-col>
-          <v-col cols="3">
-            <v-btn
-                width="100%"
-                height="58%"
-                @click="createTag(addTagsDialog.target); addTagsDialog.target.name = ''">
-              {{ $t('buttons.add') }}
-            </v-btn>
-          </v-col>
-        </v-row>
-        <v-card-actions>
-          <v-btn
-              @click="addTagsDialog.show = false"
-              color="error"
-              v-html="$t('buttons.close')"
-          />
-        </v-card-actions>
-      </v-card>
-    </v-dialog>
-    <!-- [Mobile] Edit tags dialog end -->
     <!--br/-->
 
     <!-- Submission Editor -->
@@ -391,7 +335,7 @@ import "md-editor-v3/lib/style.css";
 import MarkdownModal from "@/components/helpers/MarkdownModal.vue";
 import ExerciseService from "@/services/ExerciseService";
 import TagService from "@/services/TagService";
-import { Exercise, Tag } from "@/helpers/types";
+import { Exercise, Tag, Module } from "@/helpers/types";
 
 const route = useRoute();
 const router = useRouter();
@@ -405,6 +349,7 @@ const id = Number.parseInt(
 
 const exercise: Ref<Exercise> = ref({}) as Ref<Exercise>;
 const exerciseTags: Ref<Tag[]> = ref([]);
+const module: Ref<Module> = ref({}) as Ref<Module>;
 const allTags: Ref<Tag[]> = ref([]);
 const filteredTags: Ref<Tag[]> = ref([]);
 
@@ -443,6 +388,7 @@ const currentDialog = ref({}) as Ref;
 
 onBeforeMount(async () => {
   exercise.value = (await ExerciseService.getExercise(id)).data;
+  module.value = exercise.value.module;
   wasSave = false;
   wasDelete = false;
   window.addEventListener("beforeunload", beforeWindowUnload);
@@ -573,13 +519,27 @@ function addTagToExercise(tag: Tag): void {
   TagService.addTagToExercise(tag, exercise.value).then(() =>
     getExerciseTags()
   );
+  TagService.addTagToModule(module.value, tag);
 }
 
 async function removeTag(tag: Tag): Promise<void> {
-  //Bugged when not removing the last tag
   await TagService.delTagFromExercise(tag, exercise.value).then(() =>
     getExerciseTags()
   );
+  ExerciseService.getExercisesForModule(module.value.module_id).then(res => {
+    const resData = res.data;
+    let tagInOtherExercise = false;
+    resData.forEach((ex: Exercise) => {
+      ex.tags.forEach((exTag: Tag) => {
+        if(exTag.tag_id == tag.tag_id) {
+          tagInOtherExercise = true;
+        }
+      })
+    });
+    if(!tagInOtherExercise) {
+      TagService.delTagFromModule(module.value, tag);
+    }
+  })
 }
 
 function updateFilterList() {

--- a/src/components/exercises/ExerciseEditor.vue
+++ b/src/components/exercises/ExerciseEditor.vue
@@ -15,6 +15,7 @@
           :closable="true"
           @click:close="removeTag(tag)"
         >
+          <v-icon class="tag-icon" size="small" :icon="tag.icon.reference"/>
           {{ tag.name }}
         </v-chip>
       </div>
@@ -99,13 +100,14 @@
         <v-table :fixed-header="true" height="40vh">
           <thead>
             <tr>
-              <th>{{ $t("exercise.tag") }}</th>
+              <th class="hide-btn-behind-header">{{ $t("exercise.tag") }}</th>
               <th class="hide-btn-behind-header"></th>
             </tr>
           </thead>
           <tbody>
             <tr v-for="tag in filteredTags" :key="tag.tag_id">
               <td>
+                <v-icon class="tag-icon" size=small :icon="tag.icon.reference"/>
                 {{ tag.name }}
               </td>
               <td class="text-right">
@@ -609,5 +611,9 @@ function getTagTemplate(): Tag {
 
 .hide-btn-behind-header {
   z-index: 1;
+}
+
+.tag-icon {
+  margin-right: 0.3em;
 }
 </style>

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -51,7 +51,7 @@ export type Module = {
     module_id : number,
     name : string,
     description: string, 
-    modulePublic: string,
+    modulePublic: boolean,
     icon: Icon,
 }
 

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -12,7 +12,8 @@ export type Role = {
 }
 export type Tag = {
     tag_id: number,
-    name: string
+    name: string, 
+    icon: Icon
 }
 
 export type Submission = {
@@ -49,7 +50,9 @@ export type Rating = {
 export type Module = {
     module_id : number,
     name : string,
-    description: string
+    description: string, 
+    modulePublic: string,
+    icon: Icon,
 }
 
 export type ModuleUser = {
@@ -89,3 +92,7 @@ export type Asset = {
     filename: string,
 }
 
+export type Icon = {
+    icon_id: number,
+    reference: string,
+}

--- a/src/services/IconService.ts
+++ b/src/services/IconService.ts
@@ -1,0 +1,20 @@
+import API from "@/services/API";
+import {Icon} from "@/helpers/types";
+
+class IconService {
+    //TODO: Return / check response codes
+    getIcons(): Promise<any> {
+        return API.get(`icons`);
+    }
+
+    addIcon(icon: Icon): Promise<any> {
+        return API.post(`icons`, icon);
+    }
+
+    delIcon(icon: Icon): Promise<any> {
+        return API.delete(`icons/${icon.icon_id}`);
+    }
+    
+}
+
+export default new IconService();

--- a/src/services/TagService.ts
+++ b/src/services/TagService.ts
@@ -1,5 +1,5 @@
 import API from "@/services/API";
-import {Exercise, Tag} from "@/helpers/types"
+import {Exercise, Tag, Module} from "@/helpers/types"
 
 class TagService {
 
@@ -30,6 +30,18 @@ class TagService {
 
     delTagFromExercise(tag: Tag, exercise: Exercise): Promise<any> {
         return API.delete(`exercises/${exercise.exercise_id}/${tag.tag_id}`);
+    }
+
+    getModuleTags(module: Module) {
+        API.get(`modules/${module.module_id}/tags`);
+    }
+
+    addTagToModule(module: Module, tag: Tag) {
+        API.post(`modules/tags/${module.module_id}/${tag.tag_id}`);
+    }
+
+    delTagFromModule(module: Module, tag: Tag) {
+        API.delete(`modules/tags/${module.module_id}/${tag.tag_id}`);
     }
 
 }

--- a/src/services/TagService.ts
+++ b/src/services/TagService.ts
@@ -41,7 +41,7 @@ class TagService {
     }
 
     delTagFromModule(module: Module, tag: Tag) {
-        return API.delete(`module/tags/${module.module_id}/${tag.tag_id}`);
+        return API.delete(`modules/tags/${module.module_id}/${tag.tag_id}`);
     }
 
 }

--- a/src/services/TagService.ts
+++ b/src/services/TagService.ts
@@ -33,15 +33,15 @@ class TagService {
     }
 
     getModuleTags(module: Module) {
-        API.get(`modules/${module.module_id}/tags`);
+        return API.get(`modules/${module.module_id}/tags`);
     }
 
     addTagToModule(module: Module, tag: Tag) {
-        API.post(`modules/tags/${module.module_id}/${tag.tag_id}`);
+        return API.post(`modules/tags/${module.module_id}/${tag.tag_id}`);
     }
 
     delTagFromModule(module: Module, tag: Tag) {
-        API.delete(`modules/tags/${module.module_id}/${tag.tag_id}`);
+        return API.delete(`modules/tags/${module.module_id}/${tag.tag_id}`);
     }
 
 }

--- a/src/services/TagService.ts
+++ b/src/services/TagService.ts
@@ -41,7 +41,7 @@ class TagService {
     }
 
     delTagFromModule(module: Module, tag: Tag) {
-        return API.delete(`modules/tags/${module.module_id}/${tag.tag_id}`);
+        return API.delete(`module/tags/${module.module_id}/${tag.tag_id}`);
     }
 
 }


### PR DESCRIPTION
This PR does more than it actually should have done...
- Add icons to tags, but there is no way to change an icon right now and every tag just has a default icon set in the backend (#262)

- Add icons to modules, but there is no way to change an icon right now and every module just has a default icon set in the backend (#301)

- Filtering exercises by tags does not work correctly but I dont know why ... in theory the feature is implemented (#344)

- Implemented a way to change the visibility of a module in the ModuleManager (#357)

If someone can add a way to change the icons they can do that, if not I will implement that next week.
I spent too much time on the filtering mechanic so if someone else could give it a shot I'd be happy about that!