### PR TITLE
Add search fields on most pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "axios": "^0.27.2",
         "core-js": "^3.23.3",
         "md-editor-v3": "^2.2.0",
-        "moment": "^2.29.3",
+        "moment": "^2.29.4",
         "ress": "^5.0.2",
         "roboto-fontface": "*",
         "simple-code-editor": "^1.2.0",

--- a/src/components/admin/ModuleManagement.vue
+++ b/src/components/admin/ModuleManagement.vue
@@ -1,5 +1,13 @@
 <template>
   <div>
+    <v-text-field
+        class="mb-4 mt-1"
+        :label="$t('admin.modules.search_module')"
+        v-model="search"
+        prepend-icon="mdi-magnify"
+        single-line
+        hide-details
+        @input="applySearch"/>
     <v-card elevation="0" rounded="0" role="main">
       <!-- main table -->
       <v-table
@@ -243,18 +251,28 @@ const display = useDisplay();
 const router = useRouter();
 
 const modules: Ref<Module[]> = ref([]);
+const filteredModules: Ref<Module[]> = ref([]);
 const currentPage: Ref<Module[]> = ref([]);
 const currentPageNumber = ref(1);
 const itemsPerPage = ref(3);
 const numbers = [1,3,5,10,20,50];
 const length = ref(3);
 const i18n = useI18n();
+const search = ref("");
 const itemsPerPageLabel = i18n.t('module_search.module_per_page')
 
 async function loadModules(): Promise<void> {
-  modules.value = (await ModuleService.getModules()).data.sort(
+  filteredModules.value = modules.value = (await ModuleService.getModules()).data.sort(
       (a: Module, b: Module) => a.module_id - b.module_id
   );
+}
+
+function applySearch(): void {
+  filteredModules.value = modules.value.filter((module) => {
+    return module.name.toLowerCase().includes(search.value.toLowerCase())
+  })
+  currentPage.value = filteredModules.value.slice((currentPageNumber.value - 1) * itemsPerPage.value, currentPageNumber.value * itemsPerPage.value)
+  length.value = Math.ceil(filteredModules.value.length/itemsPerPage.value)
 }
 
 onBeforeMount(async () => {

--- a/src/components/module/ModuleManager.vue
+++ b/src/components/module/ModuleManager.vue
@@ -1,20 +1,20 @@
 <template>
   <v-container>
     <v-card v-if="!embedded">
-      <v-row no-gutters="true">
+      <v-row :no-gutters="true">
         <v-col cols="2" justify="start">
           <v-tooltip bottom>
             <template v-slot:activator="{ props: tooltip3 }">
               <v-btn
-                v-bind="tooltip3"
-                @click="goBack()"
-                class="back-button"
-                rounded="false"
+                  v-bind="tooltip3"
+                  @click="goBack()"
+                  class="back-button"
+                  icon
               >
-                <v-icon icon="mdi-arrow-left" />
+                <v-icon icon="mdi-arrow-left"/>
               </v-btn>
             </template>
-            <span v-html="$t('buttons.back')" />
+            <span v-html="$t('buttons.back')"/>
           </v-tooltip>
         </v-col>
         <v-col>
@@ -42,37 +42,55 @@
         </v-col>
       </v-row>
     </v-card>
-    <br />
+    <br/>
     <v-btn
-      @click="manageTagsDialog.show = true"
-      v-if="embedded"
-      class="embeddedEditTagsButton"
+        @click="manageTagsDialog.show = true"
+        v-if="embedded"
+        class="embeddedEditTagsButton"
     >
       {{ $t("module_manager.edit_tag_button") }}
     </v-btn>
-    <br />
-    <br />
+    <br/>
+    <br/>
     <v-card>
+      <v-row>
+        <v-col cols="auto">
+          <v-btn
+              class="add-user-btn"
+              @click="manageUsersDialog.show = true"
+              color="secondary"
+              v-html="$t('module_manager.add_user')"
+          />
+        </v-col>
+        <v-col cols="max">
+          <v-text-field
+              :label="$t('module_manager.search_user')"
+              v-model="userFilter"
+              prepend-icon="mdi-magnify"
+              single-line
+              hide-details/>
+        </v-col>
+      </v-row>
       <v-row>
         <v-col cols="12">
           <v-table>
             <thead>
-              <tr>
-                <th class="text-left">{{ $t("module_manager.name") }}</th>
-                <th class="text-left">{{ $t("module_manager.roles") }}</th>
-                <th class="text-right"></th>
-                <th class="text-right"></th>
-              </tr>
+            <tr>
+              <th class="text-left">{{ $t("module_manager.name") }}</th>
+              <th class="text-left">{{ $t("module_manager.roles") }}</th>
+              <th class="text-right"/>
+              <th class="text-right"/>
+            </tr>
             </thead>
             <tbody>
-              <tr v-for="user in moduleUsers" v-bind:key="user.user_id">
-                <td class="text-left">{{ user.name }}</td>
-                <td class="text-left">{{ user.module_role.name }}</td>
-                <td class="placeholder-td"></td>
-                <td class="text-right">
-                  <v-tooltip top>
-                    <template v-slot:activator="{ props: tooltip }">
-                      <v-btn
+            <tr v-for="user in moduleUsers.filter(u => displayUserForCurrentFilter(u))" v-bind:key="user.user_id">
+              <td class="text-left">{{ user.name }}</td>
+              <td class="text-left">{{ user.module_role.name }}</td>
+              <td class="placeholder-td"></td>
+              <td class="text-right">
+                <v-tooltip top>
+                  <template v-slot:activator="{ props: tooltip }">
+                    <v-btn
                         @click="
                           editPrivilegeDialog.show = true;
                           editPrivilegeDialog.userRole = user.module_role.name;
@@ -81,38 +99,29 @@
                         class="manage-button"
                         color="primary"
                         v-bind="tooltip"
-                      >
-                        <v-icon icon="mdi-cog"></v-icon>
-                      </v-btn>
-                    </template>
-                    <span v-html="$t('module_manager.edit_privilege')" />
-                  </v-tooltip>
-                  <v-tooltip top>
-                    <template v-slot:activator="{ props: tooltip2 }">
-                      <v-btn
+                    >
+                      <v-icon icon="mdi-cog"/>
+                    </v-btn>
+                  </template>
+                  <span v-html="$t('module_manager.edit_privilege')"/>
+                </v-tooltip>
+                <v-tooltip top>
+                  <template v-slot:activator="{ props: tooltip2 }">
+                    <v-btn
                         class="manage-button"
                         @click="deleteModuleUser(user)"
                         color="error"
                         v-bind="tooltip2"
-                      >
-                        <v-icon icon="mdi-delete"></v-icon>
-                      </v-btn>
-                    </template>
-                    <span v-html="$t('buttons.remove')" />
-                  </v-tooltip>
-                </td>
-              </tr>
+                    >
+                      <v-icon icon="mdi-delete"/>
+                    </v-btn>
+                  </template>
+                  <span v-html="$t('buttons.remove')"/>
+                </v-tooltip>
+              </td>
+            </tr>
             </tbody>
           </v-table>
-          <v-btn
-            class="add-user-btn"
-            @click="manageUsersDialog.show = true"
-            color="secondary"
-            v-html="$t('module_manager.add_user')"
-          />
-        </v-col>
-        <v-col cols="12">
-          <v-pagination></v-pagination>
         </v-col>
       </v-row>
     </v-card>
@@ -129,53 +138,53 @@
         <v-card-text>
           <v-table :fixed-header="true" height="400px">
             <thead>
-              <tr>
-                <th class="hide-btn-behind-header">
-                  {{ $t("module_manager.tag") }}
-                </th>
-                <th class="hide-btn-behind-header"></th>
-                <th class="hide-btn-behind-header"></th>
-              </tr>
+            <tr>
+              <th class="hide-btn-behind-header">
+                {{ $t("module_manager.tag") }}
+              </th>
+              <th class="hide-btn-behind-header"></th>
+              <th class="hide-btn-behind-header"></th>
+            </tr>
             </thead>
             <tbody>
-              <tr v-for="tag in tagsCurrent" v-bind:key="tag.tag_id">
-                <td class="text-center">
-                  <v-icon size="small" :icon="tag.icon.reference" />
-                </td>
-                <td>
-                  <v-container class="test-class">
-                    <v-text-field
+            <tr v-for="tag in tagsCurrent" v-bind:key="tag.tag_id">
+              <td class="text-center">
+                <v-icon size="small" :icon="tag.icon.reference"/>
+              </td>
+              <td>
+                <v-container class="test-class">
+                  <v-text-field
                       vertical-align="middle"
                       class="centered-input extend"
                       v-model="tag.name"
-                    />
-                  </v-container>
-                </td>
-                <td class="text-right">
-                  <v-btn
+                  />
+                </v-container>
+              </td>
+              <td class="text-right">
+                <v-btn
                     class="manage-button"
                     @click="editTag(tag)"
                     color="primary"
-                  >
-                    <v-icon icon="mdi-content-save"></v-icon>
-                  </v-btn>
-                  <v-btn
+                >
+                  <v-icon icon="mdi-content-save"></v-icon>
+                </v-btn>
+                <v-btn
                     class="manage-button"
                     @click="removeTag(tag)"
                     color="error"
-                  >
-                    <v-icon icon="mdi-delete"></v-icon>
-                  </v-btn>
-                </td>
-              </tr>
+                >
+                  <v-icon icon="mdi-delete"></v-icon>
+                </v-btn>
+              </td>
+            </tr>
             </tbody>
           </v-table>
         </v-card-text>
         <v-card-actions>
           <v-btn
-            @click="manageTagsDialog.show = false"
-            color="error"
-            v-html="$t('buttons.close')"
+              @click="manageTagsDialog.show = false"
+              color="error"
+              v-html="$t('buttons.close')"
           />
         </v-card-actions>
       </v-card>
@@ -186,52 +195,52 @@
     <!-- Edit users dialog start -->
     <!-- [Desktop] -->
     <v-dialog
-      class="d-none d-md-flex"
-      v-model="editPrivilegeDialog.show"
-      :retain-focus="false"
-      transition="slide-y-transition"
+        class="d-none d-md-flex"
+        v-model="editPrivilegeDialog.show"
+        :retain-focus="false"
+        transition="slide-y-transition"
     >
       <v-card top="15%" width="50vw">
         <v-card-title> {{ $t("module_manager.edit_privilege") }}</v-card-title>
         <v-card-text>
           <v-radio-group v-model="editPrivilegeDialog.userRole">
             <v-radio
-              :label="$t('module_manager.student')"
-              :key="1"
-              value="student"
+                :label="$t('module_manager.student')"
+                :key="1"
+                value="student"
             />
             <v-radio
-              :label="$t('module_manager.tutor')"
-              value="tutor"
-              :key="2"
+                :label="$t('module_manager.tutor')"
+                value="tutor"
+                :key="2"
             />
             <v-radio
-              :label="$t('module_manager.teacher')"
-              value="teacher"
-              :key="3"
+                :label="$t('module_manager.teacher')"
+                value="teacher"
+                :key="3"
             />
           </v-radio-group>
         </v-card-text>
         <v-card-actions>
           <v-btn
-            @click="
+              @click="
               editPrivilegeDialog.show = false;
               editPrivilegeDialog.userRole = null;
               editPrivilegeDialog.user = null;
             "
-            color="error"
-            v-html="$t('buttons.close')"
+              color="error"
+              v-html="$t('buttons.close')"
           />
           <v-btn
-            @click="
+              @click="
               editPrivilegeDialog.show = false;
               setUserRole(
                 editPrivilegeDialog.user,
                 editPrivilegeDialog.userRole
               );
             "
-            color="primary"
-            v-html="$t('buttons.save')"
+              color="primary"
+              v-html="$t('buttons.save')"
           />
         </v-card-actions>
       </v-card>
@@ -239,39 +248,45 @@
     <!-- [Desktop] -->
     <!-- Edit users dialog end -->
 
-    <!-- Edit users dialog start -->
+    <!-- Enrol users dialog start -->
     <!-- [Desktop] -->
     <v-dialog
-      class="d-none d-md-flex"
-      v-model="manageUsersDialog.show"
-      :retain-focus="false"
-      transition="slide-y-transition"
+        v-model="manageUsersDialog.show"
+        :retain-focus="false"
+        transition="slide-y-transition"
     >
-      <v-card top="20%" width="50vw">
+      <v-card top="20%" min-width="50vw">
         <v-card-title> {{ $t("module_manager.add_user") }}</v-card-title>
+        <v-text-field
+            class="mb-4 mt-1"
+            :label="$t('module_manager.search_user')"
+            v-model="userFilter"
+            prepend-icon="mdi-magnify"
+            single-line
+            hide-details/>
         <v-table :fixed-header="true" height="400px">
           <thead>
-            <tr>
-              <th>{{ $t("module_manager.name") }}</th>
-              <th class="hide-btn-behind-header"></th>
-            </tr>
+          <tr>
+            <th>{{ $t("module_manager.name") }}</th>
+            <th class="hide-btn-behind-header"></th>
+          </tr>
           </thead>
           <tbody>
-            <tr v-for="user in filteredUsers" v-bind:key="user.user_id">
-              <td>{{ user.name }}</td>
-              <td class="text-right">
-                <v-btn @click="addModuleUser(user.user_id)" color="primary">
-                  <v-icon icon="mdi-account-plus"></v-icon>
-                </v-btn>
-              </td>
-            </tr>
+          <tr v-for="user in filteredUsers.filter(u => displayUserForCurrentFilter(u))" v-bind:key="user.user_id">
+            <td>{{ user.name }}</td>
+            <td class="text-right">
+              <v-btn @click="addModuleUser(user.user_id)" color="primary">
+                <v-icon icon="mdi-account-plus"></v-icon>
+              </v-btn>
+            </td>
+          </tr>
           </tbody>
         </v-table>
         <v-card-actions>
           <v-btn
-            @click="manageUsersDialog.show = false"
-            color="error"
-            v-html="$t('buttons.close')"
+              @click="manageUsersDialog.show = false"
+              color="error"
+              v-html="$t('buttons.close')"
           />
         </v-card-actions>
       </v-card>
@@ -282,14 +297,14 @@
 </template>
 
 <script setup lang="ts">
-import { onBeforeMount, Ref, ref } from "vue";
-import { useRoute, useRouter } from "vue-router";
+import {onBeforeMount, Ref, ref} from "vue";
+import {useRoute, useRouter} from "vue-router";
 import UserService from "@/services/UserService";
 import ModuleService from "@/services/ModuleService";
 import TagService from "@/services/TagService";
 import ExerciseService from "@/services/ExerciseService";
-import { Exercise, Module, ModuleUser, Role, Tag, User } from "@/helpers/types";
-import { defineProps } from "vue";
+import {Exercise, Module, ModuleUser, Role, Tag, User} from "@/helpers/types";
+import {defineProps} from "vue";
 
 //Router
 const route = useRoute();
@@ -297,8 +312,9 @@ const router = useRouter();
 const module: Ref<Module> = ref({}) as Ref<Module>;
 const moduleUsers: Ref<ModuleUser[]> = ref([]);
 const allUsers: Ref<ModuleUser[]> = ref([]);
-const filteredUsers: Ref<User[]> = ref([]);
+const filteredUsers: Ref<ModuleUser[]> = ref([]);
 const tagsCurrent: Ref<Tag[]> = ref([]);
+const userFilter: Ref<string> = ref("");
 const lock = ref({
   value: "mdi-lock",
   color: "error"
@@ -308,44 +324,49 @@ defineProps<{
   embedded?: boolean;
 }>();
 
+function displayUserForCurrentFilter(user: ModuleUser | User): boolean {
+  return (user.name + ' ' + user.email + ' ' + user.username).toLowerCase().includes(userFilter.value.toLowerCase());
+}
+
 async function loadModule(): Promise<void> {
   ModuleService.getModule(
-    route.params.module instanceof Array
-      ? route.params.module[0]
-      : route.params.module
+      route.params.module instanceof Array
+          ? route.params.module[0]
+          : route.params.module
   )
-    .then((res) => {
-      module.value = res.data;
-      module.value.modulePublic ? lock.value.value = 'mdi-lock-open' : lock.value.value = 'mdi-lock';
-      module.value.modulePublic ? lock.value.color = 'success' : lock.value.color = 'error';
-    })
-    .then(() => {
-      loadAllUsers().then(() => {
-        loadFilteredUsers();
+      .then((res) => {
+        module.value = res.data;
+        module.value.modulePublic ? lock.value.value = 'mdi-lock-open' : lock.value.value = 'mdi-lock';
+        module.value.modulePublic ? lock.value.color = 'success' : lock.value.color = 'error';
+      })
+      .then(() => {
+        loadAllUsers().then(() => {
+          loadFilteredUsers();
+        });
+        loadModuleUsers();
+        getCurrentTags();
       });
-      loadModuleUsers();
-      getCurrentTags();
-    });
 }
 
 async function loadModuleUsers(): Promise<void> {
   moduleUsers.value = (
-    await ModuleService.getModuleUsers(module.value)
+      await ModuleService.getModuleUsers(module.value)
   ).data.sort((a: ModuleUser, b: ModuleUser) => a.user_id - b.user_id);
 }
 
 async function loadAllUsers(): Promise<void> {
   allUsers.value = (await UserService.getUsers()).data.sort(
-    (a: ModuleUser, b: ModuleUser) => a.user_id - b.user_id
+      (a: ModuleUser, b: ModuleUser) => a.user_id - b.user_id
   );
 }
 
 async function loadFilteredUsers(): Promise<void> {
   filteredUsers.value = allUsers.value
-    .map(({ user_id, name }) => ({ user_id, name }))
-    .filter(
-      (a) => !moduleUsers.value.map((b) => b.user_id).includes(a.user_id)
-    ) as User[];
+      .filter(
+          (user) => !moduleUsers.value.find(
+              (moduleUser) => moduleUser.user_id === user.user_id
+          )
+      ) as ModuleUser[];
 }
 
 onBeforeMount(async () => {
@@ -362,14 +383,14 @@ function addModuleUser(number: number): void {
   moduleUser.value.username = user.value.username;
   moduleUser.value.email = user.value.email;
   ModuleService.addModuleUser(module.value, moduleUser.value)
-    .then(() => loadModuleUsers())
-    .then(() => loadFilteredUsers());
+      .then(() => loadModuleUsers())
+      .then(() => loadFilteredUsers());
 }
 
 function deleteModuleUser(user: ModuleUser): void {
   ModuleService.delModuleUser(module.value, user)
-    .then(() => loadModuleUsers())
-    .then(() => loadFilteredUsers());
+      .then(() => loadModuleUsers())
+      .then(() => loadFilteredUsers());
 }
 
 function getUserTemplate(): ModuleUser {
@@ -422,21 +443,21 @@ function editTag(toBeEditedTag: Tag): void {
       //If find tag already exists with the new name
       if (foundTag.name.toLowerCase() == toBeEditedTag.name.toLowerCase()) {
         ExerciseService.getExercisesForModule(module.value.module_id).then(
-          (res) => {
-            res.data.forEach((exercise: Exercise) => {
-              exercise.tags.forEach((exerciseTag: Tag) => {
-                if (exerciseTag.tag_id == toBeEditedTag.tag_id) {
-                  tagFound = true;
-                  TagService.addTagToExercise(foundTag, exercise);
-                  TagService.delTagFromExercise(exerciseTag, exercise);
-                  TagService.delTagFromModule(module.value, toBeEditedTag);
-                  console.log(
-                    TagService.addTagToModule(module.value, foundTag)
-                  );
-                }
+            (res) => {
+              res.data.forEach((exercise: Exercise) => {
+                exercise.tags.forEach((exerciseTag: Tag) => {
+                  if (exerciseTag.tag_id == toBeEditedTag.tag_id) {
+                    tagFound = true;
+                    TagService.addTagToExercise(foundTag, exercise);
+                    TagService.delTagFromExercise(exerciseTag, exercise);
+                    TagService.delTagFromModule(module.value, toBeEditedTag);
+                    console.log(
+                        TagService.addTagToModule(module.value, foundTag)
+                    );
+                  }
+                });
               });
-            });
-          }
+            }
         );
       }
     });
@@ -456,7 +477,7 @@ function editTag(toBeEditedTag: Tag): void {
             if (allTag.name.toLowerCase() == newTag.name.toLowerCase()) {
               console.log(allTag);
               ExerciseService.getExercisesForModule(
-                module.value.module_id
+                  module.value.module_id
               ).then((res) => {
                 res.data.forEach((exercise: Exercise) => {
                   exercise.tags.forEach((exTag: Tag) => {

--- a/src/components/module/ModuleSearch.vue
+++ b/src/components/module/ModuleSearch.vue
@@ -1,5 +1,13 @@
 <template>
   <div>
+    <v-text-field
+        class="mb-4 mt-1"
+        :label="$t('module_search.search')"
+        v-model="search"
+        prepend-icon="mdi-magnify"
+        single-line
+        hide-details
+        @input="applySearch"/>
     <div id="background-card">
       <!--v-row align-content="center">
         <v-col id="content">
@@ -44,6 +52,7 @@ import {Module} from "@/helpers/types"
 import {useI18n} from "vue-i18n";
 
 const modules: Ref<Module[]> = ref([]);
+const filteredModules: Ref<Module[]> = ref([]);
 const currentPage: Ref<Module[]> = ref([]);
 const currentPageNumber = ref(1);
 const itemsPerPage = ref(3);
@@ -51,23 +60,29 @@ const numbers = [1,3,5,10,20,50];
 const length = ref(3);
 const i18n = useI18n();
 const itemsPerPageLabel = i18n.t('module_search.items_per_page')
+const search = ref('');
 
 onBeforeMount(async () => {
-  let apiModules = (await ModuleService.getModules()).data;
-  apiModules.forEach((result : Module) => {
-    modules.value.push(result);
-  });
+  filteredModules.value = modules.value = (await ModuleService.getModules()).data;
   currentPage.value = modules.value.slice((currentPageNumber.value - 1) * itemsPerPage.value, currentPageNumber.value * itemsPerPage.value)
 });
 
 watch(currentPageNumber, (newNumber) => {
-  currentPage.value = modules.value.slice((newNumber - 1) * itemsPerPage.value, newNumber * itemsPerPage.value)
+  currentPage.value = filteredModules.value.slice((newNumber - 1) * itemsPerPage.value, newNumber * itemsPerPage.value)
 })
+
+function applySearch(): void {
+  filteredModules.value = modules.value.filter((module) => {
+    return module.name.toLowerCase().includes(search.value.toLowerCase())
+  })
+  currentPage.value = filteredModules.value.slice((currentPageNumber.value - 1) * itemsPerPage.value, currentPageNumber.value * itemsPerPage.value)
+  length.value = Math.ceil(filteredModules.value.length/itemsPerPage.value)
+}
 
 watch(itemsPerPage, (newNumber) => {
   currentPageNumber.value = 1
   currentPage.value = modules.value.slice((currentPageNumber.value - 1) * newNumber, currentPageNumber.value * newNumber)
-  length.value = Math.ceil(modules.value.length/newNumber)
+  length.value = Math.ceil(filteredModules.value.length/newNumber)
 })
 
 /*//@ts-ignore

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -102,6 +102,7 @@ const translationDe = {
     module_search: {
         items_per_page: 'Einträge pro Seite',
         module_per_page: 'Module pro Seite',
+        search: 'Suche nach Modulen',
     },
     user_search: {
         users_per_page: 'Benutzer pro Seite'
@@ -191,6 +192,7 @@ const translationDe = {
             actions: 'Aktionen',
             password: 'Passwort',
             change_password: 'Passwort ändern',
+            search_user: 'Benutzer:in suchen',
             errors: {
                 required: 'Dieses Feld ist erforderlich.',
                 username_taken: 'Benutzername bereits vergeben.',
@@ -211,6 +213,7 @@ const translationDe = {
             no_description: 'Keine Beschreibung',
             created_at: 'Erstellt am',
             actions: 'Aktionen',
+            search_exercise: 'Aufgabe suchen',
             errors: {
                 required: 'Dieses Feld ist erforderlich.',
             }
@@ -224,6 +227,7 @@ const translationDe = {
             edit: 'Modul bearbeiten',
             delete: 'Modul löschen',
             delete_confirm: 'Modul "{0}" wirklich löschen?',
+            search_module: 'Modul suchen',
         },
         navbar: {
             title: 'Administration',
@@ -326,11 +330,12 @@ const translationDe = {
         edit_tag_button: 'Tags bearbeiten',
         edit_tag: 'Tags bearbeiten oder löschen',
         tag: 'Tag',
-        add_user: 'Nutzer hinzufügen',
+        add_user: 'Nutzer:in einschreiben',
         edit_privilege: 'Rolle ändern',
         student: 'Student:in',
         tutor: 'Tutor:in',
-        teacher: 'Lehrer:in'
+        teacher: 'Lehrer:in',
+        search_user: 'Nutzer:in suchen',
     },
     page_not_found: {
         error_title: "Diese Seite konnte nicht gefunden werden.",

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -322,7 +322,8 @@ const translationDe = {
         tutors: 'Tutor:innen',
         materials: 'Lernmaterial',
         enrollment: 'Selbsteinschreibung in das Modul.',
-        disenroll: 'Von diesem Modul abmelden.'
+        disenroll: 'Von diesem Modul abmelden.',
+        search_exercise: 'Aufgabe suchen',
     },
     module_manager: {
         name: 'Name',

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -100,6 +100,7 @@ const translationEn = {
     module_search: {
         items_per_page: 'Items per page',
         module_per_page: 'Modules per page',
+        search: 'Search modules',
     },
     user_search: {
         users_per_page: 'Users per page'
@@ -184,6 +185,7 @@ const translationEn = {
             actions: 'Actions',
             password: 'Password',
             change_password: 'Change password',
+            search_user: 'Search user',
             errors: {
                 required: 'This field is required.',
                 username_taken: 'This username is already taken.',
@@ -204,6 +206,7 @@ const translationEn = {
             no_description: 'No description provided',
             created_at: 'Created at',
             actions: 'Actions',
+            search_exercise: 'Search exercise',
             errors: {
                 required: 'This field is required.',
             }
@@ -217,6 +220,7 @@ const translationEn = {
             edit: 'Edit module',
             delete: 'Delete module',
             delete_confirm: 'Delete module "{0}"?',
+            search_module: 'Search module',
         },
         navbar: {
             title: 'Admin Panel',
@@ -326,11 +330,12 @@ const translationEn = {
         edit_tag_button: 'Edit tags',
         edit_tag: 'Change or delete tags',
         tag: 'Tag',
-        add_user: 'Add user',
+        add_user: 'Enrol user',
         edit_privilege: 'Change role',
         student: 'Student',
         tutor: 'Tutor',
-        teacher: 'Teacher'
+        teacher: 'Teacher',
+        search_user: 'Search user',
     },
     page_not_found: {
         error_title: "This page could not be found.",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -331,7 +331,7 @@ const translationEn = {
         edit_tag_button: 'Edit tags',
         edit_tag: 'Change or delete tags',
         tag: 'Tag',
-        add_user: 'Enrol user',
+        add_user: 'Enroll user',
         edit_privilege: 'Change role',
         student: 'Student',
         tutor: 'Tutor',

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -322,7 +322,8 @@ const translationEn = {
         tutors: 'Tutors',
         materials: 'Learning material',
         enrollment: 'Self enrollment in this module.',
-        disenroll: 'Disenroll from this module.'
+        disenroll: 'Disenroll from this module.',
+        search_exercise: 'Search exercise',
     },
     module_manager: {
         name: 'Name',


### PR DESCRIPTION
Adds search fields for...

* `/modules` - search module
* `/{id}` - search exercise
* `/{id}/manage` - search enrolled users and search for users to enroll
* `/admin/...` - search for users/modules/exercises

To test, just use them. Right now the filter is not very smart, so you can search an exercise by name *or* module name, but not both at once (a query like `modulename exercisename` will most likely not yield anything).