### PR TITLE
Clicking on notification title now marks it as read

### DIFF
--- a/src/components/user/NotificationList.vue
+++ b/src/components/user/NotificationList.vue
@@ -85,7 +85,7 @@
               <v-icon :icon="getNotificationIcon(notification)"
                       class="ma-1"/>
             </td>
-            <td v-bind="props">
+            <td v-bind="props" @click="handleClick(notification)">
                 {{ notification.title }}
             </td>
             <td @click="handleClick(notification)"


### PR DESCRIPTION
Fixed it, was just a little missing method